### PR TITLE
Fix UDV install (freeze alpaca version)

### DIFF
--- a/UDV-Core/package.json
+++ b/UDV-Core/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/MEPP-team/UDV/",
   "dependencies": {
-    "alpaca": "^1.5.24",
+    "alpaca": "1.5.24",
     "babel-runtime": "^6.20.0",
     "bootstrap": "^4.1.1",
     "es6-promise": "^4.0.5",


### PR DESCRIPTION
UDV installation is currently broken: Running install.sh from UDV-Core outputs the following error:

````
ERROR in udvcore.js from UglifyJs
Name expected [./~/alpaca/dist/alpaca/bootstrap/alpaca.js:7111,0][udvcore.js:105029,23]
npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! UDV-Core@0.0.1 build: `webpack -p`
npm ERR! Exit status 2
npm ERR! 
npm ERR! Failed at the UDV-Core@0.0.1 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

````

Freezing the alpaca version to 1.5.24 seems to do the job.