### PR TITLE
Fix/modules appearance

### DIFF
--- a/UDV-Core/examples/DemoFull/Demo.js
+++ b/UDV-Core/examples/DemoFull/Demo.js
@@ -61,8 +61,11 @@ baseDemo.loadConfigFile('../data/config/generalDemoConfig.json').then(() => {
     const docCommentsWindow = new udvcore.DocumentCommentsWindow(documents,
         docCommentsService);
 
-    ////// GEOCODING
-    const geocodingService = new udvcore.GeocodingService(requestService, baseDemo.extent, baseDemo.config);
-    const geocodingView = new udvcore.GeocodingView(geocodingService, baseDemo.controls, baseDemo.view);
-    baseDemo.addModuleView('geocoding', geocodingView, {binding: 's', name: 'Address Search'});
+    ////// GEOCODING EXTENSION
+    const geocodingService = new udvcore.GeocodingService(requestService,
+        baseDemo.extent, baseDemo.config);
+    const geocodingView = new udvcore.GeocodingView(geocodingService,
+        baseDemo.controls, baseDemo.view);
+    baseDemo.addModuleView('geocoding', geocodingView, {binding: 's',
+                                name: 'Address Search'});
 });

--- a/UDV-Core/examples/DemoFull/Demo.js
+++ b/UDV-Core/examples/DemoFull/Demo.js
@@ -29,7 +29,9 @@ baseDemo.loadConfigFile('../data/config/generalDemoConfig.json').then(() => {
     const documents = new udvcore.DocumentController(baseDemo.view,
         baseDemo.controls, {temporal: baseDemo.temporal, active: false},
         baseDemo.config);
-    baseDemo.addModuleView('documents', documents);
+    baseDemo.addModuleView('documents', documents, {
+        binding: 'd'
+    });
 
     ////// GUIDED TOURS MODULE
     const guidedtour = new udvcore.GuidedTourController(documents);
@@ -53,7 +55,7 @@ baseDemo.loadConfigFile('../data/config/generalDemoConfig.json').then(() => {
     const docToValidateView =
         new udvcore.DocToValidateView(docToValidateService, documents);
     baseDemo.addModuleView('docToValidate', docToValidateView,
-        {name: 'Documents in validation', requireAuth: true});
+        {name: 'Documents in validation', requireAuth: true, binding: 'v'});
 
     ////// DOCUMENTS COMMENTS EXTENSION
     const docCommentsService = new udvcore.DocumentCommentsService(documents,

--- a/UDV-Core/examples/DemoFull/Demo.js
+++ b/UDV-Core/examples/DemoFull/Demo.js
@@ -35,7 +35,7 @@ baseDemo.loadConfigFile('../data/config/generalDemoConfig.json').then(() => {
 
     ////// GUIDED TOURS MODULE
     const guidedtour = new udvcore.GuidedTourController(documents);
-    baseDemo.addModuleView('guidedTour', guidedtour, {name: 'Guided Tours'});
+    baseDemo.addModuleView('guidedTour', guidedtour, {name: 'Guided tours'});
 
     ////// CONTRIBUTE EXTENSION
     const contributeController = new udvcore.ContributeController(documents,

--- a/UDV-Core/index.html
+++ b/UDV-Core/index.html
@@ -22,31 +22,7 @@
                 UDV.
             </p>
             <ul>
-                <li>
-                    <h3><a href='examples/DemoTempDocs/Demo.html'>
-                        UDV Demo</a></h3>
-                    <p>Demonstrate the modules Temporal and ConsultDoc.</p>
-                    <p>In this demo you can navigate in a 4D (3D +
-                        time) representation of the city. You can also consult
-                        documents in a document browser and search
-                        them using keywords and other fields.
-                    </p>
-                </li>
-                <li>
-                    <h3><a href='examples/DemoAuthContrib/Demo.html'>UDV
-                        Authentication and Validation Demo</a></h3>
-                    <p>Demonstrate the modules Authentication and Validation.
-                    </p>
-                    <p>This Demo is an improvement of the above. You can create 
-                        user accounts
-                        and authenticate. The documents are linked to the user
-                        who created them
-                        and the submission of a new document must be checked
-                        and validated by
-                        a moderator.
-                    </p>
-                </li>
-                <li>
+                                <li>
                     <h3><a href='examples/DemoFull/Demo.html'>UDV
                         Full modules Demo</a></h3>
                     <p>Demonstrate the modules Authentication and Validation.
@@ -62,6 +38,7 @@
                         - Authentication<br>
                         - Documents to validate<br>
                         - Document comments<br>
+                        - Geocoding
                     </p>
                 </li>
                 <li>

--- a/UDV-Core/src/Extensions/Authentication/services/AuthenticationService.js
+++ b/UDV-Core/src/Extensions/Authentication/services/AuthenticationService.js
@@ -22,7 +22,6 @@ export function AuthenticationService(requestService, config) {
 
     this.initialize = function initialize() {
         this.requestService.setAuthenticationService(this);
-        console.log('Authentication service initialized');
     };
 
     this.login = async function login(formData) {

--- a/UDV-Core/src/Extensions/Authentication/views/AuthenticationView.css
+++ b/UDV-Core/src/Extensions/Authentication/views/AuthenticationView.css
@@ -7,16 +7,15 @@
     box-sizing: border-box;
     position: absolute;
     top: 0;
-    z-index: 10;
-    height: calc(100% - 50px);
+    height: 100%;
     width: 100%;
-    padding: 0 0 0 250px;
     color: black;
     font-size: 75%;
     background-color: rgba(30, 30, 30, 0.3);
     border: 1px solid rgb(90, 90, 90);
     pointer-events: auto;
     display: grid;
+    z-index: 50000;
 }
 
 #loginRegistrationWindow > div > ul {
@@ -26,7 +25,6 @@
 #loginRegistrationCloseButton {
     margin-top: 2.2vw;
     margin-left: 24.8vw;
-    z-index: 1;
     grid-column: 2;
     grid-row: 1;
     height: 2vw;

--- a/UDV-Core/src/Extensions/Authentication/views/AuthenticationView.css
+++ b/UDV-Core/src/Extensions/Authentication/views/AuthenticationView.css
@@ -6,7 +6,7 @@
     grid-template-columns: 1fr 1fr;
     box-sizing: border-box;
     position: absolute;
-    top: 50px;
+    top: 0;
     z-index: 10;
     height: calc(100% - 50px);
     width: 100%;

--- a/UDV-Core/src/Extensions/Authentication/views/AuthenticationView.js
+++ b/UDV-Core/src/Extensions/Authentication/views/AuthenticationView.js
@@ -10,7 +10,6 @@ export class AuthenticationView extends ModuleView {
 
     html() {
         return `
-              <button id="loginRegistrationCloseButton">Close</button>\
             <form id="RegistrationForm">\
                 <h2>Registration</h2> \
                 <h3 id="RegisterInfo" class=""></h3>
@@ -40,6 +39,7 @@ export class AuthenticationView extends ModuleView {
                 <div>Forgot your password?</div>\
                 <button type="button" id="LoginButton">Login</button>\
             </form>\
+            <button id="loginRegistrationCloseButton">Close</button>\
         `;
     }
 

--- a/UDV-Core/src/Extensions/Contribute/src/Contribute.css
+++ b/UDV-Core/src/Extensions/Contribute/src/Contribute.css
@@ -16,24 +16,6 @@
   font-size: 14;
 }
 
-
-#overlay {
-  display:none;
-  position: absolute;
-  z-index: 10;
-  margin : 3px;
-  margin-right: 0px;
-  left: 0;
-  border : 1px solid rgb(90,90,90);
-  text-align: center;
-  width: 16%;
-  height: 58%;
-  overflow: auto;
-  background-color: rgba(30,30,30,0.6);
-  font-size: 14;
-}
-
-
 #closeCreation{
   position: absolute;
   z-index: 40;

--- a/UDV-Core/src/Extensions/Contribute/src/Contribute.css
+++ b/UDV-Core/src/Extensions/Contribute/src/Contribute.css
@@ -61,32 +61,9 @@
   text-align: left;
 }
 
-#creationTitle{
-  display:inline-block;
-  margin-top: 20px;
-  color: white;
-  text-align: center;
-  font-size: 16px;
-  font-weight: bold;
-  overflow: hidden;
-  width: 90%;
-}
 /*Document Positioner*/
-#docPositionerFull{
-  position: absolute;
-  z-index: 10;
-  text-align: center;
-  margin: auto;
-  top: 0;
-  bottom: 10%;  left: 0;
-  right: 0;
-  width: 55%;
-  height: 55%;
+#docPositionWindow {
   display: none;
-  padding-left: 3px;
-  padding-top: 3px;
-  pointer-events: none;
-
 }
 
 #docPositionerFullImg{
@@ -120,104 +97,6 @@
 #xPosLab, #yPosLab, #zPosLab, #xQuatLab, #yQuatLab, #zQuatLab, #wQuatLab{
   font-size: 12px;
 }
-
-#setPosX, #setPosY, #setPosZ, #quatX, #quatY, #quatZ, #quatW{
-  width:80%;
-  background-color: rgb(255,255,255);
-}
-
-#inputFields{
-  padding-top: 20%;
-  padding-left: 10%;
-  padding-bottom: 20%;
-}
-
-#docPositionerSave{
-  z-index: 20;
-  left: 200px;
-  position:absolute;
-  margin : 5px;
-  font-size: 14px;
-  border: 1px solid black;
-  background-color: white;
-  color: black;
-  height: 30px;
-  pointer-events: auto;
-  bottom:20px;
-}
-
-#docPositionerCancel{
-  z-index: 20;
-  left: 15px;
-  position:absolute;
-  margin : 5px;
-  font-size: 14px;
-  border: 1px solid black;
-  background-color: white;
-  color: black;
-  height: 30px;
-  pointer-events: auto;
-  bottom:20px;
-}
-
-#moveDocument{
-  z-index: 20;
-  left: 85px;
-  position:absolute;
-  margin : 5px;
-  font-size: 14px;
-  border: 1px solid black;
-  background-color: white;
-  color: black;
-  height: 30px;
-  pointer-events: auto;
-  bottom:20px;
-}
-
-
-/*Creation window*/
-#create_title{
-  display:inline-block;
-  color: black;
-  font-size: 14px;
-  overflow: hidden;
-  width: 90%;
-  text-align: left;
-  padding-left: 20px;
-  margin-bottom: 12px;
-  border-radius: 4px;
-
-
-}
-
-#create_description{
-  display:inline-block;
-  color: black;
-  font-size: 14px;
-  overflow: hidden;
-  width: 90%;
-  height:60px;
-  text-align: left;
-  padding-left: 20px;
-  margin-bottom: 12px;
-  border-radius: 4px;
-}
-
-#uploadedFile{
-  margin-bottom: 12px;
-}
-
-#create_refDate, #create_publicationDate, #create_subject{
-  margin-bottom: 12px;
-  border-radius: 4px;
-}
-
-#create_type{
-    margin-bottom: 12px;
-    margin-left: 17px;
-    border-radius: 4px;
-}
-
 
 /*Update view*/
 #updateContainer{

--- a/UDV-Core/src/Extensions/Contribute/src/Contribute.css
+++ b/UDV-Core/src/Extensions/Contribute/src/Contribute.css
@@ -54,32 +54,6 @@
 
 }
 
-#documentPositioner{
-  z-index: 20;
-  left: 50px;
-  position:absolute;
-  margin : 5px;
-  font-size: 14px;
-  border: 1px solid black;
-  background-color: white;
-  color: black;
-  height: 30px;
-  pointer-events: auto;
-}
-
-#docCreation{
-  z-index: 20;
-  left: 160px;
-  position:absolute;
-  margin : 5px;
-  font-size: 14px;
-  border: 1px solid black;
-  background-color: white;
-  color: black;
-  height: 30px;
-  pointer-events: auto;
-}
-
 #subject{
   display:inline-block;
   overflow: hidden;
@@ -105,19 +79,12 @@
   margin: auto;
   top: 0;
   bottom: 10%;  left: 0;
-
   right: 0;
-
   width: 55%;
-
   height: 55%;
-
   display: none;
-
   padding-left: 3px;
-
   padding-top: 3px;
-
   pointer-events: none;
 
 }
@@ -238,7 +205,6 @@
 
 #uploadedFile{
   margin-bottom: 12px;
-  margin-left: 15px;
 }
 
 #create_refDate, #create_publicationDate, #create_subject{

--- a/UDV-Core/src/Extensions/Contribute/src/Contribute.css
+++ b/UDV-Core/src/Extensions/Contribute/src/Contribute.css
@@ -66,6 +66,22 @@
   display: none;
 }
 
+#docPositionerFull{
+  position: absolute;
+  z-index: 10;
+  text-align: center;
+  margin: auto;
+  top: 0;
+  bottom: 10%;  left: 0;
+  right: 0;
+  width: 55%;
+  height: 55%;
+  display: none;
+  padding-left: 3px;
+  padding-top: 3px;
+  pointer-events: none;
+}
+
 #docPositionerFullImg{
     width: 80%; /* or any custom size */
     height: 100%;

--- a/UDV-Core/src/Extensions/Contribute/src/Contribute.css
+++ b/UDV-Core/src/Extensions/Contribute/src/Contribute.css
@@ -56,20 +56,6 @@
   bottom:35px;
 }
 
-#docResearch{
-  position: absolute;
-  z-index: 20;
-  margin : 5px;
-  font-size: 14px;
-  border: 1px solid black;
-  background-color: white;
-  color: black;
-  height: 30px;
-  pointer-events: auto;
-  bottom:0px;
-
-}
-
 /*Creation window*/
 #creationContainer{
   display:none;

--- a/UDV-Core/src/Extensions/Contribute/src/Contribute.css
+++ b/UDV-Core/src/Extensions/Contribute/src/Contribute.css
@@ -1,61 +1,3 @@
-/*Browser*/
-#docBrowserCreateButton{
-  z-index: 20;
-  left: 100px;
-  position:absolute;
-  margin : 5px;
-  font-size: 14px;
-  border: 1px solid black;
-  background-color: white;
-  color: black;
-  height: 30px;
-  pointer-events: auto;
-  bottom:50px;
-}
-
-#docDeleteButton{
-  z-index: 20;
-  left: 170px;
-  position:absolute;
-  margin : 5px;
-  font-size: 14px;
-  border: 1px solid black;
-  background-color: white;
-  color: black;
-  height: 30px;
-  pointer-events: auto;
-  bottom:50px;
-
-}
-
-#docUpdateButton{
-  z-index: 20;
-  left:240px;
-  position:absolute;
-  margin : 5px;
-  font-size: 14px;
-  border: 1px solid black;
-  background-color: white;
-  color: black;
-  height: 30px;
-  pointer-events: auto;
-  bottom:50px;
-
-}
-/*Research window*/
-#docCreateButton{
-  z-index: 20;
-  position:absolute;
-  margin : 5px;
-  font-size: 14px;
-  border: 1px solid black;
-  background-color: white;
-  color: black;
-  height: 30px;
-  pointer-events: auto;
-  bottom:35px;
-}
-
 /*Creation window*/
 #creationContainer{
   display:none;
@@ -328,22 +270,6 @@
       color : black;
       background-color: rgba(30,30,30,0.6);
       font-size: 14;
-  }
-
-  #browserWindowTabs{
-    bottom:0px;
-  }
-
-  #docBrowserIndex{
-    position: absolute;
-        margin-top: 10px;
-        color: white;
-        left : 15px;
-        bottom : 100px;
-        font-size: 14px;
-        font-weight: bold;
-        overflow: hidden;
-
   }
 
   #update_title{

--- a/UDV-Core/src/Extensions/Contribute/src/Contribute.css
+++ b/UDV-Core/src/Extensions/Contribute/src/Contribute.css
@@ -364,49 +364,6 @@
       object-fit: contain;
   }
 
-#closeUpdate{
-    position: absolute;
-    z-index: 40;
-    top: 0;
-    right: 3px;
-    margin : 3px;
-    border: 1px solid black;
-    background-color: white;
-    color: black;
-    pointer-events: auto;
-
-  }
-
-  #docUpdate{
-    z-index: 20;
-    left: 100px;
-    position:absolute;
-    margin : 5px;
-    font-size: 14px;
-    border: 1px solid black;
-    background-color: white;
-    color: black;
-    height: 30px;
-    pointer-events: auto;
-    bottom:50px;
-
-  }
-
-  #updateCancel{
-    z-index: 20;
-    left:240px;
-    position:absolute;
-    margin : 5px;
-    font-size: 14px;
-    border: 1px solid black;
-    background-color: white;
-    color: black;
-    height: 30px;
-    pointer-events: auto;
-    bottom:50px;
-
-  }
-
   #updateTitle{
     display:inline-block;
     margin-top: 20px;

--- a/UDV-Core/src/Extensions/Contribute/src/Contribute.css
+++ b/UDV-Core/src/Extensions/Contribute/src/Contribute.css
@@ -128,7 +128,7 @@
     object-fit: contain;
     opacity: 0.5;
 }
-/
+
 #docPositionerFullPanel{
     bottom : 0px;
     margin-top: 20px;

--- a/UDV-Core/src/Extensions/Contribute/src/ContributeController.js
+++ b/UDV-Core/src/Extensions/Contribute/src/ContributeController.js
@@ -66,6 +66,8 @@ export function ContributeController(documentController, requestService){
     var position = cam.position;
     var quaternion = cam.quaternion;
 
+    this.visuData = new FormData();
+
     this.visuData.append("positionX", position.x);
     this.visuData.append('positionY', position.y);
     this.visuData.append('positionZ', position.z);
@@ -123,6 +125,7 @@ export function ContributeController(documentController, requestService){
     for (var pair of this.visuData.entries()){
       length +=1;
     }
+    console.log(`${length} vs ${this.numberVisuData}`)
     if(length != this.numberVisuData ){ //7 visualisation data must be provided
       alert('Please choose document position and save');
       this.documentCreate.showDocPositioner(true);
@@ -206,8 +209,7 @@ export function ContributeController(documentController, requestService){
           this.newDocData = new FormData();
           this.visuData = new FormData();
           this.documentController.getDocuments();
-          (this.documentCreate.activateCreateWindow.bind(this.documentCreate))
-            (false);
+          this.documentCreate.disable();
         }, (error) => {
           if (error.name === 'AuthNeededError') {
             alert("You should be logged in to create a document.");

--- a/UDV-Core/src/Extensions/Contribute/src/ContributeController.js
+++ b/UDV-Core/src/Extensions/Contribute/src/ContributeController.js
@@ -125,7 +125,6 @@ export function ContributeController(documentController, requestService){
     for (var pair of this.visuData.entries()){
       length +=1;
     }
-    console.log(`${length} vs ${this.numberVisuData}`)
     if(length != this.numberVisuData ){ //7 visualisation data must be provided
       alert('Please choose document position and save');
       this.documentCreate.showDocPositioner(true);

--- a/UDV-Core/src/Extensions/Contribute/src/ContributeController.js
+++ b/UDV-Core/src/Extensions/Contribute/src/ContributeController.js
@@ -10,6 +10,7 @@ import { UpdateDocument }   from './UpdateDocument.js';
 import "./Contribute.css";
 import { MAIN_LOOP_EVENTS } from 'itowns';
 import { removeEmptyValues } from '../../../Utils/DataProcessing/DataProcessing';
+import { AuthNeededError } from '../../../Utils/Request/RequestService.js';
 
 /**
  *
@@ -208,6 +209,9 @@ export function ContributeController(documentController, requestService){
           (this.documentCreate.activateCreateWindow.bind(this.documentCreate))
             (false);
         }, (error) => {
+          if (error.name === 'AuthNeededError') {
+            alert("You should be logged in to create a document.");
+          }
           console.error(error);
         });
     }
@@ -239,7 +243,10 @@ export function ContributeController(documentController, requestService){
         this.documentController.documentBrowser.startBrowser();
         this.documentController.documentBrowser.show();
       }, (error) => {
-        console.error("Failed!", error);
+        if (error.name === 'AuthNeededError') {
+          alert("You should be logged in to update a document.");
+        }
+        console.error(error);
       });
   }
 

--- a/UDV-Core/src/Extensions/Contribute/src/ContributeController.js
+++ b/UDV-Core/src/Extensions/Contribute/src/ContributeController.js
@@ -237,7 +237,7 @@ export function ContributeController(documentController, requestService){
         $('#'+this.documentUpdate.updateFormId).get(0).reset(); //clear update formular
         this.updatedData = new FormData(); //clear data
         this.documentController.reset();
-        this.documentUpdate.activateWindow(false);
+        this.documentUpdate.disable();
         this.documentController.docIndex = 0;//return to first doc
         this.documentController.documentBrowser.docIndex = 1; //reset index in browser
         this.documentController.documentBrowser.startBrowser();

--- a/UDV-Core/src/Extensions/Contribute/src/ContributeController.js
+++ b/UDV-Core/src/Extensions/Contribute/src/ContributeController.js
@@ -237,7 +237,7 @@ export function ContributeController(documentController, requestService){
         this.documentController.docIndex = 0;//return to first doc
         this.documentController.documentBrowser.docIndex = 1; //reset index in browser
         this.documentController.documentBrowser.startBrowser();
-        this.documentController.documentBrowser.activateWindow(true);
+        this.documentController.documentBrowser.show();
       }, (error) => {
         console.error("Failed!", error);
       });

--- a/UDV-Core/src/Extensions/Contribute/src/CreateDocument.js
+++ b/UDV-Core/src/Extensions/Contribute/src/CreateDocument.js
@@ -117,7 +117,8 @@ export class CreateDocument extends Window {
   windowCreated() {
     this.initialize();
     this.initializeButtons();
-    this.window.style.setProperty('left', '590px');
+    this.window.style.setProperty('left', 'unset');
+    this.window.style.setProperty('right', '10px');
     this.window.style.setProperty('top', '10px');
     this.window.style.setProperty('width', '390px');
   }

--- a/UDV-Core/src/Extensions/Contribute/src/CreateDocument.js
+++ b/UDV-Core/src/Extensions/Contribute/src/CreateDocument.js
@@ -59,15 +59,26 @@ export class CreateDocument extends Window {
   initialize()
   {
     this.docModelToSchema();
+
+    // HTML container of the pane allowing to place the document in the scene
+    var positionerContainer = document.createElement("div");
+    positionerContainer.id = "positionerContainer";
+    document.body.appendChild(positionerContainer);
+
+    positionerContainer.innerHTML =
+    '<div id="docPositionerFull">\
+    <img id="docPositionerFullImg"/></div>\
+    ';
   }
 
   get innerContentHtml() {
     return `
-    <div class="creation">
-    <div id = "creationWindow" ></div></div>
+    <div class="creation" id="creationWholePanel">
+    <div id = "creationWindow"></div>
     <div id ="creationTabs">
     <button id = "docCreation">Send</button>
     <button id = "documentPositioner">Place doc</button>
+    </div>
     </div>
     <div id="docPositionWindow">
       <div id = "inputFields" >
@@ -112,26 +123,6 @@ export class CreateDocument extends Window {
   }
 
   /**
-   * Display or hide creation view (formular)
-   */
-  //=============================================================================
-  activateCreateWindow(active){
-    if (typeof active != 'undefined')
-    {
-      this.windowIsActive = active;
-    }
-    document.getElementById(this.contributeController.creationContainerId).style.display = active  ? "block" : "none ";
-    document.getElementById('manualPos').style.display = active  ? "block" : "none ";
-    document.getElementById('positionerContainer').style.display = active  ? "block" : "none ";
-    if (!active) {
-      this.contributeController.documentController.documentResearch
-        .show();
-      this.contributeController.documentController.documentBrowser
-        .show();
-    }
-  }
-
-  /**
    * Display or hide creation view, second window (document positions)
    */
   //=============================================================================
@@ -155,10 +146,8 @@ export class CreateDocument extends Window {
   cancelPosition(){
 
     this.contributeController.visuData = new FormData(); //reset visuData form
-    this.activateManualPosition(false);
-    document.getElementById('docPositionerFull').style.display = "none ";
-    this.contributeController.documentController.documentResearch.hide();
-    this.contributeController.documentController.documentBrowser.hide();
+    document.getElementById('docPositionWindow').style.display = 'none';
+    document.getElementById('docPositionerFull').style.display = 'none';
     this.blurMetadataWindow(false);
   }
 
@@ -170,12 +159,10 @@ export class CreateDocument extends Window {
   blurMetadataWindow(blur){
 
     if(blur ==true){
-      document.getElementById('overlay').style.display = "block";
-      document.getElementById('creationContainer').style.pointerEvents ="none";
+      document.getElementById('creationWholePanel').style.pointerEvents ="none";
     }
     else{
-      document.getElementById('overlay').style.display = "none";
-      document.getElementById('creationContainer').style.pointerEvents ="auto";
+      document.getElementById('creationWholePanel').style.pointerEvents ="auto";
     }
   }
 
@@ -265,11 +252,14 @@ export class CreateDocument extends Window {
   //=============================================================================
   showDocPositioner(show){
     if(show){
+      document.getElementById('docPositionerFull').style.display = "block";
       document.getElementById('docPositionWindow').style.display = "block";
-      document.getElementById('creationWindow').style.pointerEvents ="none";
+      document.getElementById('creationWholePanel').style.pointerEvents ="none";
     }
     else {
+      document.getElementById('docPositionerFull').style.display = "none";
       document.getElementById('docPositionWindow').style.display = "none";
+      document.getElementById('creationWholePanel').style.pointerEvents ="auto";
     }
 
     this.contributeController.documentShowPosition();

--- a/UDV-Core/src/Extensions/Contribute/src/CreateDocument.js
+++ b/UDV-Core/src/Extensions/Contribute/src/CreateDocument.js
@@ -1,3 +1,5 @@
+import { Window } from "../../../Utils/GUI/js/Window";
+
 /**
  * Class: CreateDocument
  * Description :
@@ -17,13 +19,22 @@ export function CreateDocument(creationContainer, contributeController){
   this.contributeController = contributeController;
   this.creationContainer = creationContainer;
   this.browserTabs = this.contributeController.documentController.documentBrowser.browserTabID;
-  var docBrowserCreateButton = document.createElement('button');
-  docBrowserCreateButton.id = "docBrowserCreateButton";
-  var word = document.createTextNode("Create");
-  docBrowserCreateButton.appendChild(word);
-  document.getElementById(this.browserTabs).appendChild(docBrowserCreateButton);
 
-  this.contributeController.documentController.documentBrowser.refresh(); //original documentBrowser is updated with additional buttons
+  this.contributeController.documentController.documentBrowser.addEventListener(
+    Window.EVENT_CREATED, () => {
+      var docBrowserCreateButton = document.createElement('button');
+      docBrowserCreateButton.id = "docBrowserCreateButton";
+      var word = document.createTextNode("Create");
+      docBrowserCreateButton.appendChild(word);
+      document.getElementById(this.browserTabs).appendChild(docBrowserCreateButton);
+
+      this.contributeController.documentController.documentBrowser.refresh(); //original documentBrowser is updated with additional buttons
+
+      document.getElementById('docBrowserCreateButton').addEventListener('mousedown',
+      this.updateCreationWindow.bind(this),false);
+    }
+  );
+  
 
   // Whether this window is currently displayed or not.
   this.windowIsActive = this.contributeController.documentController.options.active || false;
@@ -124,7 +135,7 @@ export function CreateDocument(creationContainer, contributeController){
       this.contributeController.documentController.documentResearch
         .show();
       this.contributeController.documentController.documentBrowser
-        .activateWindow(true);
+        .show();
     }
   }
 
@@ -141,7 +152,7 @@ export function CreateDocument(creationContainer, contributeController){
 
     document.getElementById('manualPos').style.display = active  ? "block" : "none ";
     this.contributeController.documentController.documentResearch.show();
-    this.contributeController.documentController.documentBrowser.activateWindow(true);
+    this.contributeController.documentController.documentBrowser.show();
   }
 
 
@@ -155,7 +166,7 @@ export function CreateDocument(creationContainer, contributeController){
     this.activateManualPosition(false);
     document.getElementById('docPositionerFull').style.display = "none ";
     this.contributeController.documentController.documentResearch.hide();
-    this.contributeController.documentController.documentBrowser.activateWindow(false);
+    this.contributeController.documentController.documentBrowser.hide();
     this.blurMetadataWindow(false);
   }
 
@@ -251,7 +262,7 @@ export function CreateDocument(creationContainer, contributeController){
   this.updateCreationWindow = function updateCreationWindow(){
     document.getElementById('creationContainer').style.display ="block";
     this.contributeController.documentController.documentResearch.hide();
-    this.contributeController.documentController.documentBrowser.activateWindow(false);
+    this.contributeController.documentController.documentBrowser.hide();
 
   }
 
@@ -281,8 +292,6 @@ export function CreateDocument(creationContainer, contributeController){
   this.initialize();
 
   //Event listeners for buttons
-  document.getElementById('docBrowserCreateButton').addEventListener('mousedown',
-                                      this.updateCreationWindow.bind(this),false);
   document.getElementById('docCreation').addEventListener('mousedown',
     this.contributeController.documentCreation.bind(this.contributeController),false);
   document.getElementById('closeCreation').addEventListener('mousedown',

--- a/UDV-Core/src/Extensions/Contribute/src/CreateDocument.js
+++ b/UDV-Core/src/Extensions/Contribute/src/CreateDocument.js
@@ -17,7 +17,7 @@ import { Window } from "../../../Utils/GUI/js/Window";
 export class CreateDocument extends Window {
 
   constructor(creationContainer, contributeController) {
-    super('create_doc', 'Create Document');
+    super('create_doc', 'Document - Creation');
 
     this.contributeController = contributeController;
     this.creationContainer = creationContainer;

--- a/UDV-Core/src/Extensions/Contribute/src/CreateDocument.js
+++ b/UDV-Core/src/Extensions/Contribute/src/CreateDocument.js
@@ -72,38 +72,38 @@ export class CreateDocument extends Window {
   }
 
   get innerContentHtml() {
-    return `
-    <div class="creation" id="creationWholePanel">
-    <div id = "creationWindow"></div>
-    <div id ="creationTabs">
-    <button id = "docCreation">Send</button>
-    <button id = "documentPositioner">Place doc</button>
-    </div>
+    return /*html*/`
+    <div class="creation" id="${this.creationWholePanelId}">
+      <div id = "creationWindow"></div>
+      <div id ="creationTabs">
+        <button id = "docCreation">Send</button>
+        <button id = "documentPositioner">Place doc</button>
+      </div>
     </div>
     <div id="docPositionWindow">
       <div id = "inputFields" >
-      <table>
-      <tr><td><label id = "xPosLab" for="setPosX">XPosition </label></td>
-      <td><input id = "setPosX"></label></td>
-      </tr>
-      <tr><td><label id = "yPosLab" for="setPosY">YPosition</label></td>
-      <td><input id = "setPosY"></label></td>
-      </tr>
-      <tr><td><label id = "zPosLab" for="setPosZ">ZPosition</label></td>
-      <td><input id = "setPosZ"></label></td>
-      </tr>
-      <tr><td><label id = "xQuatLab" for="quatX">XQuaternion</label></td>
-      <td><input id = "quatX"></label></td>
-      </tr>
-      <tr><td><label id = "yQuatLab" for="quatY">YQuaternion</label></td>
-      <td><input id = "quatY"></label></td>
-      <tr><td><label id = "zQuatLab" for="quatZ">ZQuaternion</label></td>
-      <td><input id = "quatZ"></label></td>
-      </tr>
-      <tr><td><label id = "wQuatLab" for="quatW">WQuaternion</label></td>
-      <td><input id = "quatW"></label></td>
-      </tr>
-      </table>
+        <table>
+          <tr><td><label id = "xPosLab" for="setPosX">XPosition </label></td>
+          <td><input id = "setPosX"></label></td>
+          </tr>
+          <tr><td><label id = "yPosLab" for="setPosY">YPosition</label></td>
+          <td><input id = "setPosY"></label></td>
+          </tr>
+          <tr><td><label id = "zPosLab" for="setPosZ">ZPosition</label></td>
+          <td><input id = "setPosZ"></label></td>
+          </tr>
+          <tr><td><label id = "xQuatLab" for="quatX">XQuaternion</label></td>
+          <td><input id = "quatX"></label></td>
+          </tr>
+          <tr><td><label id = "yQuatLab" for="quatY">YQuaternion</label></td>
+          <td><input id = "quatY"></label></td>
+          <tr><td><label id = "zQuatLab" for="quatZ">ZQuaternion</label></td>
+          <td><input id = "quatZ"></label></td>
+          </tr>
+          <tr><td><label id = "wQuatLab" for="quatW">WQuaternion</label></td>
+          <td><input id = "quatW"></label></td>
+          </tr>
+        </table>
       </div>
       <div id="docPositionerFullPanel">
         <button id="docPositionerSave" type=button>Save</button>
@@ -160,9 +160,11 @@ export class CreateDocument extends Window {
 
     if(blur ==true){
       document.getElementById('creationWholePanel').style.pointerEvents ="none";
+      this.creationWholePanelElement.style.opacity = '0.5';
     }
     else{
       document.getElementById('creationWholePanel').style.pointerEvents ="auto";
+      this.creationWholePanelElement.style.opacity = '1';
     }
   }
 
@@ -245,6 +247,14 @@ export class CreateDocument extends Window {
 
   }
 
+  get creationWholePanelId() {
+    return 'creationWholePanel';
+  }
+
+  get creationWholePanelElement() {
+    return document.getElementById(this.creationWholePanelId);
+  }
+
   /**
    * Show or hide document positioner tool
    *
@@ -254,12 +264,12 @@ export class CreateDocument extends Window {
     if(show){
       document.getElementById('docPositionerFull').style.display = "block";
       document.getElementById('docPositionWindow').style.display = "block";
-      document.getElementById('creationWholePanel').style.pointerEvents ="none";
+      this.blurMetadataWindow(true);
     }
     else {
       document.getElementById('docPositionerFull').style.display = "none";
       document.getElementById('docPositionWindow').style.display = "none";
-      document.getElementById('creationWholePanel').style.pointerEvents ="auto";
+      this.blurMetadataWindow(false);
     }
 
     this.contributeController.documentShowPosition();

--- a/UDV-Core/src/Extensions/Contribute/src/CreateDocument.js
+++ b/UDV-Core/src/Extensions/Contribute/src/CreateDocument.js
@@ -14,54 +14,50 @@ import { Window } from "../../../Utils/GUI/js/Window";
   * @param { contributeController } contributeController
   */
 
-export function CreateDocument(creationContainer, contributeController){
+export class CreateDocument extends Window {
 
-  this.contributeController = contributeController;
-  this.creationContainer = creationContainer;
-  this.browserTabs = this.contributeController.documentController.documentBrowser.browserTabID;
+  constructor(creationContainer, contributeController) {
+    super('create_doc', 'Create Document');
 
-  this.contributeController.documentController.documentBrowser.addEventListener(
-    Window.EVENT_CREATED, () => {
-      var docBrowserCreateButton = document.createElement('button');
-      docBrowserCreateButton.id = "docBrowserCreateButton";
-      var word = document.createTextNode("Create");
-      docBrowserCreateButton.appendChild(word);
-      document.getElementById(this.browserTabs).appendChild(docBrowserCreateButton);
+    this.contributeController = contributeController;
+    this.creationContainer = creationContainer;
+    this.browserTabs = this.contributeController.documentController.documentBrowser.browserTabID;
 
-      this.contributeController.documentController.documentBrowser.refresh(); //original documentBrowser is updated with additional buttons
+    this.contributeController.documentController.documentBrowser.addEventListener(
+      Window.EVENT_CREATED, () => {
+        var docBrowserCreateButton = document.createElement('button');
+        docBrowserCreateButton.id = "docBrowserCreateButton";
+        var word = document.createTextNode("Create");
+        docBrowserCreateButton.appendChild(word);
+        document.getElementById(this.browserTabs).appendChild(docBrowserCreateButton);
 
-      document.getElementById('docBrowserCreateButton').addEventListener('mousedown',
-      this.updateCreationWindow.bind(this),false);
-    }
-  );
-  
+        this.contributeController.documentController.documentBrowser.refresh(); //original documentBrowser is updated with additional buttons
 
-  // Whether this window is currently displayed or not.
-  this.windowIsActive = this.contributeController.documentController.options.active || false;
-  this.windowManualIsActive = false;
+        document.getElementById('docBrowserCreateButton').addEventListener('mousedown',
+        this.updateCreationWindow.bind(this),false);
+      }
+    );
+    
+    // Whether this window is currently displayed or not.
+    this.windowIsActive = this.contributeController.documentController.options.active || false;
+    this.windowManualIsActive = false;
 
-  this.creationFormId = "creationForm"; //creation form ID.
+    this.creationFormId = "creationForm"; //creation form ID.
+
+    this.appendTo(this.contributeController.documentController.parentElement);
+    this.hide();
+    this.addEventListener(Window.EVENT_HIDDEN, () => {
+      this.contributeController.documentController.documentResearch.show();
+      this.contributeController.documentController.documentBrowser.show();
+    });
+  }
 
   /**
    * Creates the creation view
    */
   //=============================================================================
-  this.initialize = function initialize()
+  initialize()
   {
-
-    // HTML container of the document creation pane
-    this.creationContainer.innerHTML =
-    '<br/><div id = "creationTitle">Add new document</div><br/>\
-    <br/>\
-    <button id = "closeCreation">Close</button>\
-    <div class="creation">\
-    <div id = "creationWindow" ></div></div>\
-    <div id ="creationTabs">\
-    <button id = "docCreation">Send</button>\
-    <button id = "documentPositioner">Place doc</button>\
-    </div>\
-    ';
-
     this.docModelToSchema();
 
     // HTML container of the pane allowing to place the document in the scene
@@ -119,11 +115,30 @@ export function CreateDocument(creationContainer, contributeController){
     ';
   }
 
+  get innerContentHtml() {
+    return `
+    <div id = "creationTitle">Add new document</div>
+    <div class="creation">
+    <div id = "creationWindow" ></div></div>
+    <div id ="creationTabs">
+    <button id = "docCreation">Send</button>
+    <button id = "documentPositioner">Place doc</button>
+    </div>
+    `;
+  }
+
+  windowCreated() {
+    this.initialize();
+    this.initializeButtons();
+    this.window.style.setProperty('left', '590px');
+    this.window.style.setProperty('top', '10px');
+  }
+
   /**
    * Display or hide creation view (formular)
    */
   //=============================================================================
-  this.activateCreateWindow = function activateCreateWindow(active){
+  activateCreateWindow(active){
     if (typeof active != 'undefined')
     {
       this.windowIsActive = active;
@@ -143,7 +158,7 @@ export function CreateDocument(creationContainer, contributeController){
    * Display or hide creation view, second window (document positions)
    */
   //=============================================================================
-  this.activateManualPosition = function activateManualPosition(active){
+  activateManualPosition(active){
 
     if (typeof active != 'undefined')
     {
@@ -160,7 +175,7 @@ export function CreateDocument(creationContainer, contributeController){
    * Close position window, abort position selection
    */
   //=============================================================================
-  this.cancelPosition = function cancelPosition(){
+  cancelPosition(){
 
     this.contributeController.visuData = new FormData(); //reset visuData form
     this.activateManualPosition(false);
@@ -175,7 +190,7 @@ export function CreateDocument(creationContainer, contributeController){
    * document position
    */
   //=============================================================================
-  this.blurMetadataWindow = function blurMetadataWindow(blur){
+  blurMetadataWindow(blur){
 
     if(blur ==true){
       document.getElementById('overlay').style.display = "block";
@@ -192,7 +207,7 @@ export function CreateDocument(creationContainer, contributeController){
    * using Alpaca )
    */
   //=============================================================================
-  this.docModelToSchema = function docModelToSchema(){
+  docModelToSchema(){
     //only use the metadata
     var metadata = this.contributeController.documentController.documentModel.metaData;
     //schema has at least a file input
@@ -259,8 +274,8 @@ export function CreateDocument(creationContainer, contributeController){
    * Displays creation and hide other views
    */
   //=============================================================================
-  this.updateCreationWindow = function updateCreationWindow(){
-    document.getElementById('creationContainer').style.display ="block";
+  updateCreationWindow(){
+    this.enable();
     this.contributeController.documentController.documentResearch.hide();
     this.contributeController.documentController.documentBrowser.hide();
 
@@ -271,7 +286,7 @@ export function CreateDocument(creationContainer, contributeController){
    *
    */
   //=============================================================================
-  this.showDocPositioner = function showDocPositioner(show){
+  showDocPositioner(show){
     if(show){
       document.getElementById('docPositionerFull').style.display = "block";
       document.getElementById('manualPos').style.display = "block";
@@ -289,21 +304,19 @@ export function CreateDocument(creationContainer, contributeController){
     this.contributeController.documentShowPosition();
   }
 
-  this.initialize();
+  initializeButtons() {
+    //Event listeners for buttons
+    document.getElementById('docCreation').addEventListener('mousedown',
+      this.contributeController.documentCreation.bind(this.contributeController),false);
+    document.getElementById('documentPositioner').addEventListener('mousedown',
+                                  this.showDocPositioner.bind(this, true), false);
 
-  //Event listeners for buttons
-  document.getElementById('docCreation').addEventListener('mousedown',
-    this.contributeController.documentCreation.bind(this.contributeController),false);
-  document.getElementById('closeCreation').addEventListener('mousedown',
-                                this.activateCreateWindow.bind(this,false),false);
-  document.getElementById('documentPositioner').addEventListener('mousedown',
-                                this.showDocPositioner.bind(this, true), false);
-
-  document.getElementById('docPositionerSave').addEventListener('mousedown',
-  this.contributeController.getVisualizationData.bind(this.contributeController), false);
-  document.getElementById('moveDocument').addEventListener('mousedown',
-        this.contributeController.moveDoc.bind(this.contributeController), false);
-  document.getElementById('docPositionerCancel').addEventListener('mousedown',
-                                    this.cancelPosition.bind(this,false), false);
+    document.getElementById('docPositionerSave').addEventListener('mousedown',
+    this.contributeController.getVisualizationData.bind(this.contributeController), false);
+    document.getElementById('moveDocument').addEventListener('mousedown',
+          this.contributeController.moveDoc.bind(this.contributeController), false);
+    document.getElementById('docPositionerCancel').addEventListener('mousedown',
+                                      this.cancelPosition.bind(this,false), false);
+  }
 
 }

--- a/UDV-Core/src/Extensions/Contribute/src/CreateDocument.js
+++ b/UDV-Core/src/Extensions/Contribute/src/CreateDocument.js
@@ -122,7 +122,7 @@ export function CreateDocument(creationContainer, contributeController){
     document.getElementById('positionerContainer').style.display = active  ? "block" : "none ";
     if (!active) {
       this.contributeController.documentController.documentResearch
-        .activateWindow(true);
+        .show();
       this.contributeController.documentController.documentBrowser
         .activateWindow(true);
     }
@@ -140,7 +140,7 @@ export function CreateDocument(creationContainer, contributeController){
     }
 
     document.getElementById('manualPos').style.display = active  ? "block" : "none ";
-    this.contributeController.documentController.documentResearch.activateWindow(true);
+    this.contributeController.documentController.documentResearch.show();
     this.contributeController.documentController.documentBrowser.activateWindow(true);
   }
 
@@ -154,7 +154,7 @@ export function CreateDocument(creationContainer, contributeController){
     this.contributeController.visuData = new FormData(); //reset visuData form
     this.activateManualPosition(false);
     document.getElementById('docPositionerFull').style.display = "none ";
-    this.contributeController.documentController.documentResearch.activateWindow(false);
+    this.contributeController.documentController.documentResearch.hide();
     this.contributeController.documentController.documentBrowser.activateWindow(false);
     this.blurMetadataWindow(false);
   }
@@ -250,7 +250,7 @@ export function CreateDocument(creationContainer, contributeController){
   //=============================================================================
   this.updateCreationWindow = function updateCreationWindow(){
     document.getElementById('creationContainer').style.display ="block";
-    this.contributeController.documentController.documentResearch.activateWindow(false);
+    this.contributeController.documentController.documentResearch.hide();
     this.contributeController.documentController.documentBrowser.activateWindow(false);
 
   }

--- a/UDV-Core/src/Extensions/Contribute/src/CreateDocument.js
+++ b/UDV-Core/src/Extensions/Contribute/src/CreateDocument.js
@@ -59,70 +59,46 @@ export class CreateDocument extends Window {
   initialize()
   {
     this.docModelToSchema();
-
-    // HTML container of the pane allowing to place the document in the scene
-    var positionerContainer = document.createElement("div");
-    positionerContainer.id = "positionerContainer";
-    document.body.appendChild(positionerContainer);
-
-    positionerContainer.innerHTML =
-    '<div id="docPositionerFull">\
-    <img id="docPositionerFullImg"/></div>\
-    ';
-
-    // HTML container to darken the creation window when plawing the document
-    // in the scene
-    var overlay = document.createElement("div");
-    overlay.id = "overlay";
-    document.body.appendChild(overlay);
-
-    // HTML container of the pane displaying the current position of the
-    // document while in "place document mode"
-    var manualPositionsWindow = document.createElement("div");
-    manualPositionsWindow.id = "manualPos";
-    document.body.appendChild(manualPositionsWindow);
-
-    manualPositionsWindow.innerHTML=
-    '<div id = "inputFields" >\
-    <table>\
-    <tr><td><label id = "xPosLab" for="setPosX">XPosition </label></td>\
-    <td><input id = "setPosX"></label></td>\
-    </tr>\
-    <tr><td><label id = "yPosLab" for="setPosY">YPosition</label></td>\
-    <td><input id = "setPosY"></label></td>\
-    </tr>\
-    <tr><td><label id = "zPosLab" for="setPosZ">ZPosition</label></td>\
-    <td><input id = "setPosZ"></label></td>\
-    </tr>\
-    <tr><td><label id = "xQuatLab" for="quatX">XQuaternion</label></td>\
-    <td><input id = "quatX"></label></td>\
-    </tr>\
-    <tr><td><label id = "yQuatLab" for="quatY">YQuaternion</label></td>\
-    <td><input id = "quatY"></label></td>\
-    <tr><td><label id = "zQuatLab" for="quatZ">ZQuaternion</label></td>\
-    <td><input id = "quatZ"></label></td>\
-    </tr>\
-    <tr><td><label id = "wQuatLab" for="quatW">WQuaternion</label></td>\
-    <td><input id = "quatW"></label></td>\
-    </tr>\
-    </table>\
-    </div>\
-    <div id="docPositionerFullPanel">\
-        <button id="docPositionerSave" type=button>Save</button>\
-        <button id="moveDocument" type=button>Go to position</button>\
-        <button id = "docPositionerCancel" type=button>Cancel</button>\
-    </div>\
-    ';
   }
 
   get innerContentHtml() {
     return `
-    <div id = "creationTitle">Add new document</div>
     <div class="creation">
     <div id = "creationWindow" ></div></div>
     <div id ="creationTabs">
     <button id = "docCreation">Send</button>
     <button id = "documentPositioner">Place doc</button>
+    </div>
+    <div id="docPositionWindow">
+      <div id = "inputFields" >
+      <table>
+      <tr><td><label id = "xPosLab" for="setPosX">XPosition </label></td>
+      <td><input id = "setPosX"></label></td>
+      </tr>
+      <tr><td><label id = "yPosLab" for="setPosY">YPosition</label></td>
+      <td><input id = "setPosY"></label></td>
+      </tr>
+      <tr><td><label id = "zPosLab" for="setPosZ">ZPosition</label></td>
+      <td><input id = "setPosZ"></label></td>
+      </tr>
+      <tr><td><label id = "xQuatLab" for="quatX">XQuaternion</label></td>
+      <td><input id = "quatX"></label></td>
+      </tr>
+      <tr><td><label id = "yQuatLab" for="quatY">YQuaternion</label></td>
+      <td><input id = "quatY"></label></td>
+      <tr><td><label id = "zQuatLab" for="quatZ">ZQuaternion</label></td>
+      <td><input id = "quatZ"></label></td>
+      </tr>
+      <tr><td><label id = "wQuatLab" for="quatW">WQuaternion</label></td>
+      <td><input id = "quatW"></label></td>
+      </tr>
+      </table>
+      </div>
+      <div id="docPositionerFullPanel">
+        <button id="docPositionerSave" type=button>Save</button>
+        <button id="moveDocument" type=button>Go to position</button>
+        <button id = "docPositionerCancel" type=button>Cancel</button>
+      </div>
     </div>
     `;
   }
@@ -132,6 +108,7 @@ export class CreateDocument extends Window {
     this.initializeButtons();
     this.window.style.setProperty('left', '590px');
     this.window.style.setProperty('top', '10px');
+    this.window.style.setProperty('width', '390px');
   }
 
   /**
@@ -288,17 +265,11 @@ export class CreateDocument extends Window {
   //=============================================================================
   showDocPositioner(show){
     if(show){
-      document.getElementById('docPositionerFull').style.display = "block";
-      document.getElementById('manualPos').style.display = "block";
-      document.getElementById('inputFields').style.display = "block";
-      document.getElementById('overlay').style.display = "block";
-      document.getElementById('creationContainer').style.pointerEvents ="none";
-
+      document.getElementById('docPositionWindow').style.display = "block";
+      document.getElementById('creationWindow').style.pointerEvents ="none";
     }
     else {
-      document.getElementById('docPositionerFull').style.display = "none";
-      document.getElementById('manualPos').style.display = "none";
-      document.getElementById('inputFields').style.display = "none";
+      document.getElementById('docPositionWindow').style.display = "none";
     }
 
     this.contributeController.documentShowPosition();

--- a/UDV-Core/src/Extensions/Contribute/src/UpdateDocument.js
+++ b/UDV-Core/src/Extensions/Contribute/src/UpdateDocument.js
@@ -1,3 +1,5 @@
+import { Window } from "../../../Utils/GUI/js/Window";
+
 /**
  * Class: UpdateDocument
  * Description :
@@ -41,17 +43,24 @@ export function UpdateDocument(updateContainer, contributeController){
 
   this.initialize = function initialize()
   {
-    var docUpdateButton = document.createElement('button');
-    docUpdateButton.id = "docUpdateButton";
-    var text = document.createTextNode("Update");
-    docUpdateButton.appendChild(text);
-    document.getElementById(this.contributeController.documentController.documentBrowser.browserTabID).appendChild(docUpdateButton);
+    this.contributeController.documentController.documentBrowser.addEventListener(
+      Window.EVENT_CREATED, () => {
+        var docUpdateButton = document.createElement('button');
+        docUpdateButton.id = "docUpdateButton";
+        var text = document.createTextNode("Update");
+        docUpdateButton.appendChild(text);
+        document.getElementById(this.contributeController.documentController.documentBrowser.browserTabID).appendChild(docUpdateButton);
 
-    var docDeleteButton = document.createElement('button');
-    docDeleteButton.id = "docDeleteButton";
-    var text = document.createTextNode("Delete");
-    docDeleteButton.appendChild(text);
-    document.getElementById(this.contributeController.documentController.documentBrowser.browserTabID).appendChild(docDeleteButton);
+        var docDeleteButton = document.createElement('button');
+        docDeleteButton.id = "docDeleteButton";
+        var text = document.createTextNode("Delete");
+        docDeleteButton.appendChild(text);
+        document.getElementById(this.contributeController.documentController.documentBrowser.browserTabID).appendChild(docDeleteButton);
+
+        document.getElementById('docUpdateButton').addEventListener('mousedown', this.updateDoc.bind(this),false);
+        document.getElementById('docDeleteButton').addEventListener('mousedown', this.contributeController.documentDelete.bind(this.contributeController),false);
+      }
+    );
 
     this.updateContainer.innerHTML =
     '<br/><div id = "updateTitle">You can update following information:</div><br/>\
@@ -136,7 +145,7 @@ export function UpdateDocument(updateContainer, contributeController){
 
     this.activateWindow(true);
     this.fillUpdateForm();
-    this.contributeController.documentController.documentBrowser.activateWindow(false);
+    this.contributeController.documentController.documentBrowser.hide();
   }
 
   /**
@@ -159,18 +168,16 @@ export function UpdateDocument(updateContainer, contributeController){
   //=============================================================================
   this.cancelUpdate = function cancelUpdate(){
     this.activateWindow(false);
-    this.contributeController.documentController.documentBrowser.activateWindow(true);
+    this.contributeController.documentController.documentBrowser.show();
 
   }
 
   this.initialize();
 
-  document.getElementById('docUpdateButton').addEventListener('mousedown', this.updateDoc.bind(this),false);
+
+  document.getElementById('docUpdate').addEventListener('mousedown', this.contributeController.documentUpdate.bind(this.contributeController),false);
   document.getElementById('closeUpdate').addEventListener('mousedown', this.activateWindow.bind(this,false),false);
 
   document.getElementById('updateCancel').addEventListener('mousedown', this.cancelUpdate.bind(this),false);
-
-  document.getElementById('docUpdate').addEventListener('mousedown', this.contributeController.documentUpdate.bind(this.contributeController),false);
-  document.getElementById('docDeleteButton').addEventListener('mousedown', this.contributeController.documentDelete.bind(this.contributeController),false);
 
 }

--- a/UDV-Core/src/Extensions/Contribute/src/UpdateDocument.js
+++ b/UDV-Core/src/Extensions/Contribute/src/UpdateDocument.js
@@ -91,7 +91,8 @@ export class UpdateDocument extends Window {
 
   windowCreated() {
     this.initializeButtons();
-    this.window.style.setProperty('left', '590px');
+    this.window.style.setProperty('left', 'unset');
+    this.window.style.setProperty('right', '10px');
     this.window.style.setProperty('top', '10px');
     this.window.style.setProperty('width', '390px');
   }

--- a/UDV-Core/src/Extensions/Contribute/src/UpdateDocument.js
+++ b/UDV-Core/src/Extensions/Contribute/src/UpdateDocument.js
@@ -47,6 +47,7 @@ export class UpdateDocument extends Window {
     this.hide();
     this.addEventListener(Window.EVENT_HIDDEN, () => {
       this.contributeController.documentController.documentBrowser.show();
+      this.contributeController.documentController.documentResearch.show();
     });
     this.initialize();
   }
@@ -151,6 +152,7 @@ export class UpdateDocument extends Window {
     this.enable();
     this.fillUpdateForm();
     this.contributeController.documentController.documentBrowser.hide();
+    this.contributeController.documentController.documentResearch.hide();
   }
 
   /**

--- a/UDV-Core/src/Extensions/Contribute/src/UpdateDocument.js
+++ b/UDV-Core/src/Extensions/Contribute/src/UpdateDocument.js
@@ -86,7 +86,11 @@ export function UpdateDocument(updateContainer, contributeController){
       this.windowIsActive = active;
     }
     document.getElementById(this.contributeController.updateContainerId).style.display = active  ? "block" : "none ";
-
+    if (!active) {
+      this.contributeController.documentController.documentBrowser.show();
+    } else {
+      this.contributeController.documentController.documentBrowser.hide();
+    }
   }
 
   /**

--- a/UDV-Core/src/Extensions/Contribute/src/UpdateDocument.js
+++ b/UDV-Core/src/Extensions/Contribute/src/UpdateDocument.js
@@ -17,7 +17,7 @@ import { Window } from "../../../Utils/GUI/js/Window";
 export class UpdateDocument extends Window {
 
   constructor(updateContainer, contributeController) {
-    super('update_doc', 'Update Document')
+    super('update_doc', 'Document - Update')
     this.contributeController = contributeController;
     this.updateContainer = updateContainer;
     this.browser = this.contributeController.documentController.documentBrowser;

--- a/UDV-Core/src/Extensions/DocToValidate/services/DocToValidateService.js
+++ b/UDV-Core/src/Extensions/DocToValidate/services/DocToValidateService.js
@@ -24,7 +24,7 @@ export function DocToValidateService(requestService, config) {
     this.observers = [];
 
     this.initialize = function () {
-        console.log('Doc To Validate Service initialized.');
+
     };
 
     this.getDocumentsToValidate = async function () {

--- a/UDV-Core/src/Extensions/DocToValidate/views/DocToValidateBrowserWindow.js
+++ b/UDV-Core/src/Extensions/DocToValidate/views/DocToValidateBrowserWindow.js
@@ -46,7 +46,8 @@ export class DocToValidateBrowserWindow extends Window {
     }
 
     windowCreated() {
-        this.window.style.setProperty('left', '590px');
+        this.window.style.setProperty('left', 'unset');
+        this.window.style.setProperty('right', '10px');
         this.window.style.setProperty('top', '10px');
         this.window.style.setProperty('width', '390px');
         this.browserButtonBinding();

--- a/UDV-Core/src/Extensions/DocToValidate/views/DocToValidateBrowserWindow.js
+++ b/UDV-Core/src/Extensions/DocToValidate/views/DocToValidateBrowserWindow.js
@@ -163,12 +163,11 @@ export class DocToValidateBrowserWindow extends Window {
         document.getElementById('docFull').style.display = 'block';
         let currentDocument = this.docToValidateService.currentDocument();
         let currentMetadata = currentDocument.metaData;
-        let src = this.docToValidateView.documentController.url + this.docToValidateView.documentController.serverModel.document + '/' + currentMetadata.id + '/' + this.docToValidateView.documentController.serverModel.file;
-        document.getElementById('docFullImg').src = currentDocument.imgUrl;
-        document.getElementById('docBrowserPreviewImg').src = currentDocument.imgUrl;
-        document.getElementById('docFullImg').style.opacity = 50;
+        let src = document.getElementById('docToValidate_Browser_file').src;
+        document.getElementById('docFullImg').src = src;
+        document.getElementById('docFullImg').style.opacity = 0;
         document.getElementById('docOpaSlider').value = 0;
-        document.querySelector('#docOpacity').value = 50;
+        document.querySelector('#docOpacity').value = 0;
         document.getElementById('docFull').style.display = 'block';
         document.getElementById('docFullPanel').style.display = 'block';
 
@@ -196,8 +195,8 @@ export class DocToValidateBrowserWindow extends Window {
             this.docToValidateView.documentController.temporal.changeTime(docDate);
         }
 
-        this.isOrientingDoc = true;
-        this.isFadingDoc = false;
+        this.docToValidateView.documentController.documentBrowser.isOrientingDoc = true;
+        this.docToValidateView.documentController.documentBrowser.isFadingDoc = false;
 
         this.docToValidateView.documentController.view.notifyChange();
     }

--- a/UDV-Core/src/Extensions/DocToValidate/views/DocToValidateBrowserWindow.js
+++ b/UDV-Core/src/Extensions/DocToValidate/views/DocToValidateBrowserWindow.js
@@ -46,7 +46,7 @@ export class DocToValidateBrowserWindow extends Window {
     }
 
     windowCreated() {
-        this.window.style.setProperty('left', '610px');
+        this.window.style.setProperty('left', '590px');
         this.window.style.setProperty('top', '10px');
         this.window.style.setProperty('width', '390px');
         this.browserButtonBinding();

--- a/UDV-Core/src/Extensions/DocToValidate/views/DocToValidateBrowserWindow.js
+++ b/UDV-Core/src/Extensions/DocToValidate/views/DocToValidateBrowserWindow.js
@@ -46,7 +46,7 @@ export class DocToValidateBrowserWindow extends Window {
     }
 
     windowCreated() {
-        this.window.style.setProperty('left', '700px');
+        this.window.style.setProperty('left', '610px');
         this.window.style.setProperty('top', '80px');
         this.window.style.setProperty('width', '390px');
         this.browserButtonBinding();

--- a/UDV-Core/src/Extensions/DocToValidate/views/DocToValidateBrowserWindow.js
+++ b/UDV-Core/src/Extensions/DocToValidate/views/DocToValidateBrowserWindow.js
@@ -6,7 +6,7 @@ import { removeEmptyValues } from '../../../Utils/DataProcessing/DataProcessing'
 export class DocToValidateBrowserWindow extends Window {
 
     constructor(docToValidateView, docToValidateService) {
-        super('docToValidateBrowser', 'Document navigator', false);
+        super('docToValidateBrowser', 'Validation - Browser', false);
         this.docToValidateService = docToValidateService;
         this.docToValidateView = docToValidateView;
         this.docToValidateService.addObserver(this.update.bind(this));

--- a/UDV-Core/src/Extensions/DocToValidate/views/DocToValidateBrowserWindow.js
+++ b/UDV-Core/src/Extensions/DocToValidate/views/DocToValidateBrowserWindow.js
@@ -47,7 +47,7 @@ export class DocToValidateBrowserWindow extends Window {
 
     windowCreated() {
         this.window.style.setProperty('left', '610px');
-        this.window.style.setProperty('top', '80px');
+        this.window.style.setProperty('top', '10px');
         this.window.style.setProperty('width', '390px');
         this.browserButtonBinding();
         this.docToValidateService.getDocumentsToValidate();

--- a/UDV-Core/src/Extensions/DocToValidate/views/DocToValidateCommentWindow.js
+++ b/UDV-Core/src/Extensions/DocToValidate/views/DocToValidateCommentWindow.js
@@ -50,7 +50,7 @@ export class DocToValidateCommentWindow extends Window {
         this.window.style.setProperty('width', '500px');
         this.window.style.setProperty('height', '500px');
         this.window.style.setProperty('left', '1010px');
-        this.window.style.setProperty('top', '80px');
+        this.window.style.setProperty('top', '10px');
         this.window.style.setProperty('resize', 'both');
         this.innerContent.style.setProperty('height', '100%');
         document.getElementById('docToValidateComment_inputButton').onclick = this.publishComment.bind(this);

--- a/UDV-Core/src/Extensions/DocToValidate/views/DocToValidateCommentWindow.js
+++ b/UDV-Core/src/Extensions/DocToValidate/views/DocToValidateCommentWindow.js
@@ -49,7 +49,7 @@ export class DocToValidateCommentWindow extends Window {
     windowCreated() {
         this.window.style.setProperty('width', '500px');
         this.window.style.setProperty('height', '500px');
-        this.window.style.setProperty('left', '1010px');
+        this.window.style.setProperty('left', '990px');
         this.window.style.setProperty('top', '10px');
         this.window.style.setProperty('resize', 'both');
         this.innerContent.style.setProperty('height', '100%');

--- a/UDV-Core/src/Extensions/DocToValidate/views/DocToValidateCommentWindow.js
+++ b/UDV-Core/src/Extensions/DocToValidate/views/DocToValidateCommentWindow.js
@@ -49,7 +49,7 @@ export class DocToValidateCommentWindow extends Window {
     windowCreated() {
         this.window.style.setProperty('width', '500px');
         this.window.style.setProperty('height', '500px');
-        this.window.style.setProperty('left', '990px');
+        this.window.style.setProperty('left', '290px');
         this.window.style.setProperty('top', '10px');
         this.window.style.setProperty('resize', 'both');
         this.innerContent.style.setProperty('height', '100%');

--- a/UDV-Core/src/Extensions/DocToValidate/views/DocToValidateCommentWindow.js
+++ b/UDV-Core/src/Extensions/DocToValidate/views/DocToValidateCommentWindow.js
@@ -49,7 +49,7 @@ export class DocToValidateCommentWindow extends Window {
     windowCreated() {
         this.window.style.setProperty('width', '500px');
         this.window.style.setProperty('height', '500px');
-        this.window.style.setProperty('left', '1100px');
+        this.window.style.setProperty('left', '1010px');
         this.window.style.setProperty('top', '80px');
         this.window.style.setProperty('resize', 'both');
         this.innerContent.style.setProperty('height', '100%');

--- a/UDV-Core/src/Extensions/DocToValidate/views/DocToValidateCommentWindow.js
+++ b/UDV-Core/src/Extensions/DocToValidate/views/DocToValidateCommentWindow.js
@@ -4,7 +4,7 @@ import '../../../Utils/GUI/css/window.css';
 export class DocToValidateCommentWindow extends Window {
 
     constructor(docToValidateService) {
-        super('docToValidateComment', 'Commentaires', false);
+        super('docToValidateComment', 'Comments', false);
         this.docToValidateService = docToValidateService;
     }
 

--- a/UDV-Core/src/Extensions/DocToValidate/views/DocToValidateCommentWindow.js
+++ b/UDV-Core/src/Extensions/DocToValidate/views/DocToValidateCommentWindow.js
@@ -58,7 +58,6 @@ export class DocToValidateCommentWindow extends Window {
     }
 
     publishComment() {
-        console.log('enter')
         let form = document.getElementById('docToValidateComment_inputForm');
         let form_data = new FormData(form);
         this.docToValidateService.publishComment(form_data).then(() => {

--- a/UDV-Core/src/Extensions/DocToValidate/views/DocToValidateSearchWindow.js
+++ b/UDV-Core/src/Extensions/DocToValidate/views/DocToValidateSearchWindow.js
@@ -45,7 +45,6 @@ export class DocToValidateSearchWindow extends Window {
         this.window.style.setProperty('left', '310px');
         this.window.style.setProperty('top', '10px');
         this.window.style.setProperty('width', '270px');
-        this.window.style.setProperty('height', '360px');
     }
 
     search() {

--- a/UDV-Core/src/Extensions/DocToValidate/views/DocToValidateSearchWindow.js
+++ b/UDV-Core/src/Extensions/DocToValidate/views/DocToValidateSearchWindow.js
@@ -42,7 +42,7 @@ export class DocToValidateSearchWindow extends Window {
 
     windowCreated() {
         document.getElementById('docToValidate_searchForm_submit').onclick = this.search.bind(this);
-        this.window.style.setProperty('left', '310px');
+        this.window.style.setProperty('left', '10px');
         this.window.style.setProperty('top', '10px');
         this.window.style.setProperty('width', '270px');
     }

--- a/UDV-Core/src/Extensions/DocToValidate/views/DocToValidateSearchWindow.js
+++ b/UDV-Core/src/Extensions/DocToValidate/views/DocToValidateSearchWindow.js
@@ -42,8 +42,8 @@ export class DocToValidateSearchWindow extends Window {
 
     windowCreated() {
         document.getElementById('docToValidate_searchForm_submit').onclick = this.search.bind(this);
-        this.window.style.setProperty('top', '80px');
         this.window.style.setProperty('left', '310px');
+        this.window.style.setProperty('top', '10px');
         this.window.style.setProperty('width', '270px');
         this.window.style.setProperty('height', '360px');
     }

--- a/UDV-Core/src/Extensions/DocToValidate/views/DocToValidateSearchWindow.js
+++ b/UDV-Core/src/Extensions/DocToValidate/views/DocToValidateSearchWindow.js
@@ -4,7 +4,7 @@ import '../../../Utils/GUI/css/window.css';
 export class DocToValidateSearchWindow extends Window {
 
     constructor(docToValidateView, docToValidateService) {
-        super('docToValidateSearch', 'Research', false);
+        super('docToValidateSearch', 'Validation - Search', false);
         this.docToValidateService = docToValidateService;
         this.docToValidateView = docToValidateView;
         this.addListener((event) => {

--- a/UDV-Core/src/Extensions/DocToValidate/views/DocToValidateSearchWindow.js
+++ b/UDV-Core/src/Extensions/DocToValidate/views/DocToValidateSearchWindow.js
@@ -44,7 +44,7 @@ export class DocToValidateSearchWindow extends Window {
         document.getElementById('docToValidate_searchForm_submit').onclick = this.search.bind(this);
         this.window.style.setProperty('top', '80px');
         this.window.style.setProperty('left', '310px');
-        this.window.style.setProperty('width', '380px');
+        this.window.style.setProperty('width', '270px');
         this.window.style.setProperty('height', '360px');
     }
 

--- a/UDV-Core/src/Extensions/DocToValidate/views/DocToValidateStyle.css
+++ b/UDV-Core/src/Extensions/DocToValidate/views/DocToValidateStyle.css
@@ -2,7 +2,6 @@
     position: absolute;
     width: 380px;
     max-height: 90%;
-    top: 80px;
     left: 300px;
     background-color: rgba(30,30,30,0.6);
     border : 1px solid rgb(90,90,90);

--- a/UDV-Core/src/Extensions/DocumentComments/views/DocumentCommentsStyle.css
+++ b/UDV-Core/src/Extensions/DocumentComments/views/DocumentCommentsStyle.css
@@ -1,17 +1,3 @@
-#docBrowserCommentButton {
-    z-index: 20;
-    left: 10px;
-    position: absolute;
-    margin: 5px;
-    font-size: 14px;
-    border: 1px solid black;
-    background-color: white;
-    color: black;
-    height: 30px;
-    pointer-events: auto;
-    bottom: 50px;
-}
-
 #documentComments_innerWindow {
     width: 100%;
     height: 100%;

--- a/UDV-Core/src/Extensions/DocumentComments/views/DocumentCommentsWindow.js
+++ b/UDV-Core/src/Extensions/DocumentComments/views/DocumentCommentsWindow.js
@@ -26,6 +26,12 @@ export class DocumentCommentsWindow extends Window {
                     }
                 };
         });
+
+        documentController.addEventListener(
+            Window.EVENT_DISABLED, () => {
+                this.disable();
+            }
+        );
         
         this.appendTo(document.getElementById('contentSection'));
         this.hide();
@@ -73,8 +79,8 @@ export class DocumentCommentsWindow extends Window {
     windowCreated() {
         this.window.style.setProperty('width', '500px');
         this.window.style.setProperty('height', '500px');
-        this.window.style.setProperty('left', '310px');
-        this.window.style.setProperty('top', '80px');
+        this.window.style.setProperty('left', '990px');
+        this.window.style.setProperty('top', '60px');
         this.window.style.setProperty('resize', 'both');
         this.innerContent.style.setProperty('height', '100%');
         document.getElementById('documentComments_inputButton').onclick = this.publishComment.bind(this);

--- a/UDV-Core/src/Extensions/DocumentComments/views/DocumentCommentsWindow.js
+++ b/UDV-Core/src/Extensions/DocumentComments/views/DocumentCommentsWindow.js
@@ -88,7 +88,6 @@ export class DocumentCommentsWindow extends Window {
     }
 
     publishComment() {
-        console.log('enter')
         let form = document.getElementById('documentComments_inputForm');
         let form_data = new FormData(form);
         this.documentCommentsService.publishComment(form_data).then(() => {

--- a/UDV-Core/src/Extensions/DocumentComments/views/DocumentCommentsWindow.js
+++ b/UDV-Core/src/Extensions/DocumentComments/views/DocumentCommentsWindow.js
@@ -33,7 +33,7 @@ export class DocumentCommentsWindow extends Window {
             }
         );
         
-        this.appendTo(document.getElementById('contentSection'));
+        this.appendTo(documentController.parentElement);
         this.hide();
     }
 
@@ -80,7 +80,7 @@ export class DocumentCommentsWindow extends Window {
         this.window.style.setProperty('width', '500px');
         this.window.style.setProperty('height', '500px');
         this.window.style.setProperty('left', '990px');
-        this.window.style.setProperty('top', '60px');
+        this.window.style.setProperty('top', '10px');
         this.window.style.setProperty('resize', 'both');
         this.innerContent.style.setProperty('height', '100%');
         document.getElementById('documentComments_inputButton').onclick = this.publishComment.bind(this);

--- a/UDV-Core/src/Extensions/DocumentComments/views/DocumentCommentsWindow.js
+++ b/UDV-Core/src/Extensions/DocumentComments/views/DocumentCommentsWindow.js
@@ -5,7 +5,7 @@ import './DocumentCommentsStyle.css';
 export class DocumentCommentsWindow extends Window {
 
     constructor(documentController, documentCommentsService) {
-        super('documentComments', 'Commentaires');
+        super('documentComments', 'Comments');
         this.documentCommentsService = documentCommentsService;
         this.documentController = documentController;
 

--- a/UDV-Core/src/Extensions/DocumentComments/views/DocumentCommentsWindow.js
+++ b/UDV-Core/src/Extensions/DocumentComments/views/DocumentCommentsWindow.js
@@ -9,20 +9,24 @@ export class DocumentCommentsWindow extends Window {
         this.documentCommentsService = documentCommentsService;
         this.documentController = documentController;
 
-        let browserTabs = documentController.documentBrowser.browserTabID;
-        let docBrowserCreateButton = document.createElement('button');
-        docBrowserCreateButton.id = "docBrowserCommentButton";
-        let word = document.createTextNode("Comment");
-        docBrowserCreateButton.appendChild(word);
-        document.getElementById(browserTabs).appendChild(docBrowserCreateButton);
-        docBrowserCreateButton.onclick = () => {
-            if (this.isVisible) {
-                this.hide();
-            } else {
-                this.show();
-                this.getComments();
-            }
-        };
+        documentController.documentBrowser.addEventListener(
+            Window.EVENT_CREATED, () => {
+                let browserTabs = documentController.documentBrowser.browserTabID;
+                let docBrowserCreateButton = document.createElement('button');
+                docBrowserCreateButton.id = "docBrowserCommentButton";
+                let word = document.createTextNode("Comment");
+                docBrowserCreateButton.appendChild(word);
+                document.getElementById(browserTabs).appendChild(docBrowserCreateButton);
+                docBrowserCreateButton.onclick = () => {
+                    if (this.isVisible) {
+                        this.hide();
+                    } else {
+                        this.show();
+                        this.getComments();
+                    }
+                };
+        });
+        
         this.appendTo(document.getElementById('contentSection'));
         this.hide();
     }

--- a/UDV-Core/src/Extensions/DocumentComments/views/DocumentCommentsWindow.js
+++ b/UDV-Core/src/Extensions/DocumentComments/views/DocumentCommentsWindow.js
@@ -79,7 +79,7 @@ export class DocumentCommentsWindow extends Window {
     windowCreated() {
         this.window.style.setProperty('width', '500px');
         this.window.style.setProperty('height', '500px');
-        this.window.style.setProperty('left', '990px');
+        this.window.style.setProperty('left', '290px');
         this.window.style.setProperty('top', '10px');
         this.window.style.setProperty('resize', 'both');
         this.innerContent.style.setProperty('height', '100%');

--- a/UDV-Core/src/Extensions/Geocoding/views/GeocodingStyle.css
+++ b/UDV-Core/src/Extensions/Geocoding/views/GeocodingStyle.css
@@ -1,6 +1,6 @@
 #_geocoding_view {
   position: absolute;
-  top: 80px;
+  top: 30px;
   width: 100%;
 }
 

--- a/UDV-Core/src/Extensions/Geocoding/views/GeocodingView.js
+++ b/UDV-Core/src/Extensions/Geocoding/views/GeocodingView.js
@@ -284,6 +284,7 @@ export class GeocodingView extends ModuleView {
    * @override
    */
   async disableView() {
+    
     await this.dispose();
   }
 }

--- a/UDV-Core/src/Extensions/Geocoding/views/GeocodingView.js
+++ b/UDV-Core/src/Extensions/Geocoding/views/GeocodingView.js
@@ -285,6 +285,5 @@ export class GeocodingView extends ModuleView {
    */
   async disableView() {
     await this.dispose();
-    console.log('hello');
   }
 }

--- a/UDV-Core/src/Extensions/Geocoding/views/GeocodingView.js
+++ b/UDV-Core/src/Extensions/Geocoding/views/GeocodingView.js
@@ -59,19 +59,24 @@ export class GeocodingView extends ModuleView {
    * Destroys the view.
    */
   dispose() {
-    if (this.isCreated) {
-      let div = this.viewElement;
-      let input = this.searchInputElement;
-      input.style.transition = 'width 0.3s ease-out, opacity 0.4s ease-out'
-      input.style.width = '0';
-      input.style.opacity = '0';
-      input.ontransitionend = (event) => {
-        if (event.propertyName === "opacity") {
-          div.parentElement.removeChild(div);
-          this.removePins();
+    return new Promise((resolve, reject) => {
+      if (this.isCreated) {
+        let div = this.viewElement;
+        let input = this.searchInputElement;
+        input.style.transition = 'width 0.3s ease-out, opacity 0.4s ease-out'
+        input.style.width = '0';
+        input.style.opacity = '0';
+        input.ontransitionend = (event) => {
+          if (event.propertyName === "opacity") {
+            div.parentElement.removeChild(div);
+            this.removePins();
+            resolve();
+          }
         }
+      } else {
+        resolve();
       }
-    }
+    });
   }
 
   /**
@@ -268,11 +273,18 @@ export class GeocodingView extends ModuleView {
   //////////// MODULE VIEW METHODS
   ////////////////////////////////
 
-  enableView() {
+  /**
+   * @override
+   */
+  async enableView() {
     this.appendToElement(this.parentElement);
   }
 
-  disableView() {
-    this.dispose();
+  /**
+   * @override
+   */
+  async disableView() {
+    await this.dispose();
+    console.log('hello');
   }
 }

--- a/UDV-Core/src/Modules/ConsultDoc/ConsultDoc.css
+++ b/UDV-Core/src/Modules/ConsultDoc/ConsultDoc.css
@@ -76,15 +76,9 @@
 }
 
 #docBrowserIndex{
-  position: absolute;
-      margin-top: 10px;
-      color: white;
-      left : 15px;
-      bottom : 100px;
-      font-size: 14px;
-      font-weight: bold;
-      overflow: hidden;
-
+  color: white;
+  font-size: 14px;
+  font-weight: bold;
 }
 
 #docType{
@@ -127,62 +121,6 @@
     width: 100%; /* or any custom size */
     height: 100%;
     object-fit: contain;
-}
-
-#docBrowserNextButton{
-    position: absolute;
-    z-index: 20;
-    bottom : 5px;
-    left: 60px;
-    margin: auto;
-    font-size: 30px;
-    border: 1px solid black;
-    background-color: white;
-    color: black;
-    height: 40px;
-    pointer-events: auto;
-}
-
-#docBrowserPreviousButton{
-    position: absolute;
-    z-index: 20;
-    bottom : 0;
-    left : 0;
-    margin : 5px;
-    font-size: 30px;
-    border: 1px solid black;
-    background-color: white;
-    color: black;
-    height: 40px;
-    pointer-events: auto;
-}
-
-#docBrowserOrientButton{
-    position: absolute;
-    z-index: 20;
-    bottom : 0;
-    right : 0;
-    margin : 5px;
-    font-size: 14px;
-    border: 1px solid black;
-    background-color: white;
-    color: black;
-    height: 30px;
-    pointer-events: auto;
-}
-
-#resetFilters{
-    z-index: 20;
-    bottom : 0;
-    left: 130px;
-    position:absolute;
-    margin : 5px;
-    font-size: 14px;
-    border: 1px solid black;
-    background-color: white;
-    color: black;
-    height: 30px;
-    pointer-events: auto;
 }
 
 #docFull{

--- a/UDV-Core/src/Modules/ConsultDoc/ConsultDoc.css
+++ b/UDV-Core/src/Modules/ConsultDoc/ConsultDoc.css
@@ -24,10 +24,6 @@
   width: 90%;
 }
 
-#filtersWindow {
-  margin-bottom: 10px;
-}
-
 #docBrowserWindow{
     position: absolute;
     z-index: 10;

--- a/UDV-Core/src/Modules/ConsultDoc/ConsultDoc.css
+++ b/UDV-Core/src/Modules/ConsultDoc/ConsultDoc.css
@@ -24,6 +24,10 @@
   width: 90%;
 }
 
+#filtersWindow {
+  margin-bottom: 10px;
+}
+
 #docBrowserWindow{
     position: absolute;
     z-index: 10;
@@ -389,19 +393,10 @@
   width: 90%;
     height:20px;
 }
+
 label{
   left:3px
 }
-#keyword{
-  display:inline-block;
-  color: black;
-  text-align: center;
-  font-size: 14px;
-  width: 90%;
-  text-align: left;
-  padding-left: 20px;
-}
-
 
 #browserInfo{
 display: block;

--- a/UDV-Core/src/Modules/ConsultDoc/DocumentBrowser.js
+++ b/UDV-Core/src/Modules/ConsultDoc/DocumentBrowser.js
@@ -88,30 +88,9 @@ export class DocumentBrowser extends Window {
         this.initializeButtons();
         this.resetResearch();
     }
-/*
-    // Display or hide this window
-    activateWindow(active) {
-        if (typeof active != 'undefined') {
-            this.windowIsActive = active;
-        }
-
-        if (this.documentsExist && this.isStart) {
-            this.startBrowser();
-            this.isStart = false;
-        }
-        document.getElementById('browserContainer').style.display
-            = active ? 'block' : 'none';
-        document.getElementById('docBrowserWindow').style.display
-            = active ? 'block' : 'none';
-        if (active) {
-            this.documentController.open();
-        } else {
-            this.documentController.close();
-        }
-    };*/
 
     refresh() {
-        //this.activateWindow(this.windowIsActive);
+        
     };
 
     // called regularly by the itowns framerequester
@@ -250,9 +229,9 @@ export class DocumentBrowser extends Window {
             + this.documentController.serverModel.document + '/'
             + this.currentMetadata.id + '/'
             + this.documentController.serverModel.file;
-        document.getElementById('docFullImg').style.opacity = 50;
+        document.getElementById('docFullImg').style.opacity = 0;
         document.getElementById('docOpaSlider').value = 0;
-        document.querySelector('#docOpacity').value = 50;
+        document.querySelector('#docOpacity').value = 0;
         document.getElementById('docFull').style.display = 'block';
         document.getElementById('docFullPanel').style.display = 'block';
 

--- a/UDV-Core/src/Modules/ConsultDoc/DocumentBrowser.js
+++ b/UDV-Core/src/Modules/ConsultDoc/DocumentBrowser.js
@@ -82,7 +82,8 @@ export class DocumentBrowser extends Window {
     }
 
     windowCreated() {
-        this.window.style.setProperty('left', '590px');
+        this.window.style.setProperty('left', 'unset');
+        this.window.style.setProperty('right', '10px');
         this.window.style.setProperty('top', '10px');
         this.window.style.setProperty('width', '390px');
         this.initializeButtons();

--- a/UDV-Core/src/Modules/ConsultDoc/DocumentBrowser.js
+++ b/UDV-Core/src/Modules/ConsultDoc/DocumentBrowser.js
@@ -8,6 +8,7 @@
 import * as THREE from 'three';
 import { MAIN_LOOP_EVENTS } from 'itowns';
 import DefaultImage from './DefaultImage.png';
+import { Window } from '../../Utils/GUI/js/Window';
 
 /**
  *
@@ -16,68 +17,75 @@ import DefaultImage from './DefaultImage.png';
  * @param { documentController } documentController
  */
 
-export function DocumentBrowser(browserContainer, documentController) {
-    // class attributes
-    this.documentController = documentController;
-    this.documentsExist = true;
-    this.currentDoc = null;
-    this.windowIsActive = false;
-    this.isOrientingDoc = false;
-    this.isFadingDoc = false;
-    this.fadeAlpha = 0;
-    this.docIndex = 1;
-    this.isStart = true; // dirty variable to test if we are in start mode
-    this.currentMetadata;
-    this.numberDocs;
-    // ID of the html div holding buttons in the browser
-    // will be used by other classes as well to add extra buttons
-    this.browserTabID = 'browserWindowTabs';
-    // doc fade-in animation duration, in milliseconds
-    this.fadeDuration = this.documentController.options.docFadeDuration || 2750;
+export class DocumentBrowser extends Window {
+    constructor(browserContainer, documentController) {
+        super('consultDocBrowser', 'Document Browser', false);
+        // class attributes
+        this.documentController = documentController;
+        this.documentsExist = true;
+        this.currentDoc = null;
+        this.windowIsActive = false;
+        this.isOrientingDoc = false;
+        this.isFadingDoc = false;
+        this.fadeAlpha = 0;
+        this.docIndex = 1;
+        this.isStart = true; // dirty variable to test if we are in start mode
+        this.currentMetadata;
+        this.numberDocs;
+        // ID of the html div holding buttons in the browser
+        // will be used by other classes as well to add extra buttons
+        this.browserTabID = 'browserWindowTabs';
+        // doc fade-in animation duration, in milliseconds
+        this.fadeDuration = this.documentController.options.docFadeDuration || 2750;
 
-    browserContainer.innerHTML =
-        '<div id="docBrowserWindow">\
-        <button id="closeBrowserWindow" type=button>Close</button><br/>\
-          <div id="docHead">Document browser</div><br>\
-          <br/>\
-          <div id="browserInfo"></div>\
-          <div id = "docBrowserInfo"></div>\
-          <div id="docBrowserPreview"><img id="docBrowserPreviewImg"/></div>\
-          <div id="docBrowserIndex"></div>\
-      </div>\
-      ';
+        var docFull = document.createElement('div');
+        docFull.id = 'docFull';
+        document.body.appendChild(docFull);
 
-    var browserWindowTabs = document.createElement('div');
-    browserWindowTabs.id = this.browserTabID;
-    document.getElementById('docBrowserWindow').appendChild(browserWindowTabs);
+        docFull.innerHTML =
+            '<img id="docFullImg"/>\
+            <div id="docFullPanel">\
+                <button id="docFullClose" type=button>Close</button>\
+                <button id="docFullOrient" type=button>Orient Document</button>\
+                <label id="docOpaLabel" for="docOpaSlider">Opacity</label>\
+                <input id="docOpaSlider" type="range" min="0" max="100" value="75"\
+                step="1">\
+                <output for="docOpaSlider" id="docOpacity">50</output>\
+            ';
 
-    browserWindowTabs.innerHTML =
-        '<button id="docBrowserNextButton" type=button>⇨</button>\
-      <button id="docBrowserPreviousButton" type=button>⇦</button>\
-      <button id="resetFilters" type=button>Reset research</button>\
-      <button id="docBrowserOrientButton" type=button>Orient Document</button>\
-      ';
+        // Whether this window is currently displayed or not.
+        this.windowIsActive = this.documentController.options.active || false;
 
-    var docFull = document.createElement('div');
-    docFull.id = 'docFull';
-    document.body.appendChild(docFull);
+        // itowns framerequester : will regularly call this.updateScene()
+        this.documentController.view.addFrameRequester(
+            MAIN_LOOP_EVENTS.AFTER_CAMERA_UPDATE, this.updateScene.bind(this));
+    }
 
-    docFull.innerHTML =
-        '<img id="docFullImg"/>\
-          <div id="docFullPanel">\
-              <button id="docFullClose" type=button>Close</button>\
-              <button id="docFullOrient" type=button>Orient Document</button>\
-              <label id="docOpaLabel" for="docOpaSlider">Opacity</label>\
-              <input id="docOpaSlider" type="range" min="0" max="100" value="75"\
-              step="1">\
-              <output for="docOpaSlider" id="docOpacity">50</output>\
-          ';
+    get innerContentHtml() {
+        return `
+            <div id="browserInfo"></div>
+            <div id="docBrowserInfo"></div>
+            <div id="docBrowserPreview"><img id="docBrowserPreviewImg"/></div>
+            <div id="docBrowserIndex"></div>
+            <div id="${this.browserTabID}">
+                <button id="docBrowserPreviousButton" type=button>⇦</button>
+                <button id="docBrowserNextButton" type=button>⇨</button>
+                <button id="resetFilters" type=button>Reset research</button>
+                <button id="docBrowserOrientButton" type=button>Orient Document</button>
+            </div>
+        `;
+    }
 
-    // Whether this window is currently displayed or not.
-    this.windowIsActive = this.documentController.options.active || false;
-
+    windowCreated() {
+        this.window.style.setProperty('left', '590px');
+        this.window.style.setProperty('top', '60px');
+        this.window.style.setProperty('width', '390px');
+        this.initializeButtons();
+        this.resetResearch();
+    }
+/*
     // Display or hide this window
-    this.activateWindow = function activateWindow(active) {
+    activateWindow(active) {
         if (typeof active != 'undefined') {
             this.windowIsActive = active;
         }
@@ -95,60 +103,62 @@ export function DocumentBrowser(browserContainer, documentController) {
         } else {
             this.documentController.close();
         }
-    };
+    };*/
 
-    this.refresh = function refresh() {
-        this.activateWindow(this.windowIsActive);
+    refresh() {
+        //this.activateWindow(this.windowIsActive);
     };
 
     // called regularly by the itowns framerequester
     //= ========================================================================
-    this.updateScene = function updateScene(dt, updateLoopRestarted) {
-        // dt will not be relevant when we just started rendering, we consider a 1-frame move in this case
-        if (updateLoopRestarted) {
-            dt = 16;
-        }
-        // controls.state === -1 corresponds to state === STATE.NONE
-        // if state is -1 this means the controls have finished the animated travel
-        // then we can begin the doc fade animation
-        if (this.isOrientingDoc && this.documentController.controls.state === -1) {
-            this.isOrientingDoc = false;
-            this.isFadingDoc = true;
-            this.fadeAlpha = 0;
-            document.getElementById('docOpaSlider').value = 0;
-            document.querySelector('#docOpacity').value = 0;
-            document.getElementById('docFullImg').style.opacity = 0;
-            document.getElementById('docFullPanel').style.display = 'block';
-        }
-
-        // handle fade animation
-        if (this.isFadingDoc) {
-            this.fadeAlpha += dt / this.fadeDuration;
-            if (this.fadeAlpha >= 1) {
-                // animation is complete
-                this.isFadingDoc = false;
-                document.getElementById('docFullImg').style.opacity = 1;
-                document.getElementById('docOpaSlider').value = 100;
-                document.querySelector('#docOpacity').value = 100;
+    updateScene(dt, updateLoopRestarted) {
+        if (this.isCreated) {
+            // dt will not be relevant when we just started rendering, we consider a 1-frame move in this case
+            if (updateLoopRestarted) {
+                dt = 16;
             }
-            else {
-                // if not complete :
-                document.getElementById('docFullImg').style.opacity = this.fadeAlpha;
-                document.getElementById('docOpaSlider').value = this.fadeAlpha * 100;
-                document.querySelector('#docOpacity').value =
-                    Math.trunc(this.fadeAlpha * 100);
+            // controls.state === -1 corresponds to state === STATE.NONE
+            // if state is -1 this means the controls have finished the animated travel
+            // then we can begin the doc fade animation
+            if (this.isOrientingDoc && this.documentController.controls.state === -1) {
+                this.isOrientingDoc = false;
+                this.isFadingDoc = true;
+                this.fadeAlpha = 0;
+                document.getElementById('docOpaSlider').value = 0;
+                document.querySelector('#docOpacity').value = 0;
+                document.getElementById('docFullImg').style.opacity = 0;
+                document.getElementById('docFullPanel').style.display = 'block';
             }
 
-            // request redraw of the scene
-            this.documentController.view.notifyChange();
+            // handle fade animation
+            if (this.isFadingDoc) {
+                this.fadeAlpha += dt / this.fadeDuration;
+                if (this.fadeAlpha >= 1) {
+                    // animation is complete
+                    this.isFadingDoc = false;
+                    document.getElementById('docFullImg').style.opacity = 1;
+                    document.getElementById('docOpaSlider').value = 100;
+                    document.querySelector('#docOpacity').value = 100;
+                }
+                else {
+                    // if not complete :
+                    document.getElementById('docFullImg').style.opacity = this.fadeAlpha;
+                    document.getElementById('docOpaSlider').value = this.fadeAlpha * 100;
+                    document.querySelector('#docOpacity').value =
+                        Math.trunc(this.fadeAlpha * 100);
+                }
+
+                // request redraw of the scene
+                this.documentController.view.notifyChange();
+            }
         }
-    };
+    }
 
     /**
      * Updates browser by clicking on "nextDoc" button
      */
     //= ============================================================================
-    this.nextDoc = function nextDoc() {
+    nextDoc() {
         if (this.docIndex < this.numberDocs & this.currentDoc != null) {
             this.docIndex++;
             this.currentDoc = this.documentController.getNextDoc();
@@ -162,7 +172,7 @@ export function DocumentBrowser(browserContainer, documentController) {
      * Updates browser by click on "previousDoc" button
      */
     //= ============================================================================
-    this.previousDoc = function previousDoc() {
+    previousDoc() {
         if (this.docIndex > 1 & this.currentDoc != null) {
             this.docIndex--;
             this.currentDoc = this.documentController.getPreviousDoc();
@@ -177,7 +187,10 @@ export function DocumentBrowser(browserContainer, documentController) {
     // the document browser html is defined based
     // on the documentModel metadata attributes
     //= =========================================================================
-    this.updateBrowser = function updateBrowser() {
+    updateBrowser() {
+        if (!this.isCreated) {
+            return;
+        }
         if (this.currentDoc != null & this.numberDocs > 0) {
             var txt = '';
             txt += "<div id ='docMetadata'>";
@@ -226,7 +239,7 @@ export function DocumentBrowser(browserContainer, documentController) {
     // this will display the doc image in the middle of the screen
     // and initiate the animated travel to orient the camera
     //= ============================================================================
-    this.focusOnDoc = function focusOnDoc() {
+    focusOnDoc() {
         document.getElementById('docFull').style.display = 'block';
         let src = this.documentController.url + this.documentController.serverModel.document + '/' + this.currentMetadata.id + '/' + this.documentController.serverModel.file;
         console.log(src);
@@ -276,12 +289,12 @@ export function DocumentBrowser(browserContainer, documentController) {
 
     // close the central window superposition view
     //= ========================================================================
-    this.closeDocFull = function closeDocFull() {
+    closeDocFull() {
         document.getElementById('docFull').style.display = 'none';
         // document.getElementById('docFullImg').src = null;
     };
 
-    this.startBrowser = function startBrowser() {
+    startBrowser() {
         try {
             this.documentController.getDocuments();
         } catch (e) {
@@ -298,7 +311,7 @@ export function DocumentBrowser(browserContainer, documentController) {
         this.updateBrowser();
     };
 
-    this.resetResearch = function resetResearch() {
+    resetResearch() {
         this.docIndex = 1;
         $(`#${this.documentController.documentResearch.filterFormId}`).get(0).reset(); // reset reserach parameters
 
@@ -311,27 +324,24 @@ export function DocumentBrowser(browserContainer, documentController) {
         this.closeDocFull();
     };
 
-    // itowns framerequester : will regularly call this.updateScene()
-    this.documentController.view.addFrameRequester(
-        MAIN_LOOP_EVENTS.AFTER_CAMERA_UPDATE, this.updateScene.bind(this));
 
-    // event listeners for buttons
-    document.getElementById('docFullOrient').addEventListener('mousedown',
-        this.focusOnDoc.bind(this), false);
-    document.getElementById('docFullClose').addEventListener('mousedown',
-        this.closeDocFull.bind(this), false);
-    document.getElementById('docBrowserNextButton').addEventListener('mousedown',
-        this.nextDoc.bind(this), false);
-    document.getElementById('docBrowserPreviousButton').addEventListener('mousedown',
-        this.previousDoc.bind(this), false);
-    document.getElementById('docBrowserOrientButton').addEventListener('mousedown',
-        this.focusOnDoc.bind(this), false);
-    document.getElementById('closeBrowserWindow').addEventListener('mousedown',
-        this.documentController.disable.bind(this.documentController), false);
-    document.getElementById('resetFilters').addEventListener('mousedown',
-        this.resetResearch.bind(this), false);
-    document.getElementById('docOpaSlider').addEventListener('input',
-        docOpaUpdate, false);
+    initializeButtons() {
+        // event listeners for buttons
+        document.getElementById('docFullOrient').addEventListener('mousedown',
+            this.focusOnDoc.bind(this), false);
+        document.getElementById('docFullClose').addEventListener('mousedown',
+            this.closeDocFull.bind(this), false);
+        document.getElementById('docBrowserNextButton').addEventListener('mousedown',
+            this.nextDoc.bind(this), false);
+        document.getElementById('docBrowserPreviousButton').addEventListener('mousedown',
+            this.previousDoc.bind(this), false);
+        document.getElementById('docBrowserOrientButton').addEventListener('mousedown',
+            this.focusOnDoc.bind(this), false);
+        document.getElementById('resetFilters').addEventListener('mousedown',
+            this.resetResearch.bind(this), false);
+        document.getElementById('docOpaSlider').addEventListener('input',
+            docOpaUpdate, false);
+    }
 }
 
 // In oriented view (focusOnDoc) this is called when the user changes the value

--- a/UDV-Core/src/Modules/ConsultDoc/DocumentBrowser.js
+++ b/UDV-Core/src/Modules/ConsultDoc/DocumentBrowser.js
@@ -282,7 +282,12 @@ export function DocumentBrowser(browserContainer, documentController) {
     };
 
     this.startBrowser = function startBrowser() {
-        this.documentController.getDocuments();
+        try {
+            this.documentController.getDocuments();
+        } catch (e) {
+            //view is not created ?
+            return;
+        }
         this.docIndex = 1;
         this.currentDoc = this.documentController.setOfDocuments[0];
         try {

--- a/UDV-Core/src/Modules/ConsultDoc/DocumentBrowser.js
+++ b/UDV-Core/src/Modules/ConsultDoc/DocumentBrowser.js
@@ -144,40 +144,16 @@ export class DocumentBrowser extends Window {
                 document.getElementById('docOpaSlider').value = 100;
                 document.querySelector('#docOpacity').value = 100;
             }
-            // controls.state === -1 corresponds to state === STATE.NONE
-            // if state is -1 this means the controls have finished the animated travel
-            // then we can begin the doc fade animation
-            if (this.isOrientingDoc && this.documentController.controls.state === -1) {
-                this.isOrientingDoc = false;
-                this.isFadingDoc = true;
-                this.fadeAlpha = 0;
-                document.getElementById('docOpaSlider').value = 0;
-                document.querySelector('#docOpacity').value = 0;
-                document.getElementById('docFullImg').style.opacity = 0;
-                document.getElementById('docFullPanel').style.display = 'block';
+            else {
+                // if not complete :
+                document.getElementById('docFullImg').style.opacity = this.fadeAlpha;
+                document.getElementById('docOpaSlider').value = this.fadeAlpha * 100;
+                document.querySelector('#docOpacity').value =
+                    Math.trunc(this.fadeAlpha * 100);
             }
 
-            // handle fade animation
-            if (this.isFadingDoc) {
-                this.fadeAlpha += dt / this.fadeDuration;
-                if (this.fadeAlpha >= 1) {
-                    // animation is complete
-                    this.isFadingDoc = false;
-                    document.getElementById('docFullImg').style.opacity = 1;
-                    document.getElementById('docOpaSlider').value = 100;
-                    document.querySelector('#docOpacity').value = 100;
-                }
-                else {
-                    // if not complete :
-                    document.getElementById('docFullImg').style.opacity = this.fadeAlpha;
-                    document.getElementById('docOpaSlider').value = this.fadeAlpha * 100;
-                    document.querySelector('#docOpacity').value =
-                        Math.trunc(this.fadeAlpha * 100);
-                }
-
-                // request redraw of the scene
-                this.documentController.view.notifyChange();
-            }
+            // request redraw of the scene
+            this.documentController.view.notifyChange();
         }
     }
 

--- a/UDV-Core/src/Modules/ConsultDoc/DocumentBrowser.js
+++ b/UDV-Core/src/Modules/ConsultDoc/DocumentBrowser.js
@@ -277,6 +277,7 @@ export class DocumentBrowser extends Window {
             this.documentController.getDocuments();
         } catch (e) {
             //view is not created ?
+            console.error(e);
             return;
         }
         this.docIndex = 1;

--- a/UDV-Core/src/Modules/ConsultDoc/DocumentBrowser.js
+++ b/UDV-Core/src/Modules/ConsultDoc/DocumentBrowser.js
@@ -83,7 +83,7 @@ export class DocumentBrowser extends Window {
 
     windowCreated() {
         this.window.style.setProperty('left', '590px');
-        this.window.style.setProperty('top', '60px');
+        this.window.style.setProperty('top', '10px');
         this.window.style.setProperty('width', '390px');
         this.initializeButtons();
         this.resetResearch();

--- a/UDV-Core/src/Modules/ConsultDoc/DocumentBrowser.js
+++ b/UDV-Core/src/Modules/ConsultDoc/DocumentBrowser.js
@@ -19,7 +19,7 @@ import { Window } from '../../Utils/GUI/js/Window';
 
 export class DocumentBrowser extends Window {
     constructor(browserContainer, documentController) {
-        super('consultDocBrowser', 'Document Browser', false);
+        super('consultDocBrowser', 'Document - Browser', false);
         // class attributes
         this.documentController = documentController;
         this.documentsExist = true;

--- a/UDV-Core/src/Modules/ConsultDoc/DocumentBrowser.js
+++ b/UDV-Core/src/Modules/ConsultDoc/DocumentBrowser.js
@@ -224,7 +224,6 @@ export class DocumentBrowser extends Window {
     focusOnDoc() {
         document.getElementById('docFull').style.display = 'block';
         let src = this.documentController.url + this.documentController.serverModel.document + '/' + this.currentMetadata.id + '/' + this.documentController.serverModel.file;
-        console.log(src);
         document.getElementById('docFullImg').src = this.documentController.url
             + this.documentController.serverModel.document + '/'
             + this.currentMetadata.id + '/'

--- a/UDV-Core/src/Modules/ConsultDoc/DocumentBrowser.js
+++ b/UDV-Core/src/Modules/ConsultDoc/DocumentBrowser.js
@@ -144,16 +144,40 @@ export class DocumentBrowser extends Window {
                 document.getElementById('docOpaSlider').value = 100;
                 document.querySelector('#docOpacity').value = 100;
             }
-            else {
-                // if not complete :
-                document.getElementById('docFullImg').style.opacity = this.fadeAlpha;
-                document.getElementById('docOpaSlider').value = this.fadeAlpha * 100;
-                document.querySelector('#docOpacity').value =
-                    Math.trunc(this.fadeAlpha * 100);
+            // controls.state === -1 corresponds to state === STATE.NONE
+            // if state is -1 this means the controls have finished the animated travel
+            // then we can begin the doc fade animation
+            if (this.isOrientingDoc && this.documentController.controls.state === -1) {
+                this.isOrientingDoc = false;
+                this.isFadingDoc = true;
+                this.fadeAlpha = 0;
+                document.getElementById('docOpaSlider').value = 0;
+                document.querySelector('#docOpacity').value = 0;
+                document.getElementById('docFullImg').style.opacity = 0;
+                document.getElementById('docFullPanel').style.display = 'block';
             }
 
-            // request redraw of the scene
-            this.documentController.view.notifyChange();
+            // handle fade animation
+            if (this.isFadingDoc) {
+                this.fadeAlpha += dt / this.fadeDuration;
+                if (this.fadeAlpha >= 1) {
+                    // animation is complete
+                    this.isFadingDoc = false;
+                    document.getElementById('docFullImg').style.opacity = 1;
+                    document.getElementById('docOpaSlider').value = 100;
+                    document.querySelector('#docOpacity').value = 100;
+                }
+                else {
+                    // if not complete :
+                    document.getElementById('docFullImg').style.opacity = this.fadeAlpha;
+                    document.getElementById('docOpaSlider').value = this.fadeAlpha * 100;
+                    document.querySelector('#docOpacity').value =
+                        Math.trunc(this.fadeAlpha * 100);
+                }
+
+                // request redraw of the scene
+                this.documentController.view.notifyChange();
+            }
         }
     }
 

--- a/UDV-Core/src/Modules/ConsultDoc/DocumentController.js
+++ b/UDV-Core/src/Modules/ConsultDoc/DocumentController.js
@@ -71,6 +71,9 @@ export class DocumentController extends ModuleView {
     browserContainer.style = 'display: none;';
     document.getElementById('contentSection').appendChild(browserContainer);
     this.documentBrowser = new DocumentBrowser(browserContainer, this);
+    this.documentBrowser.addEventListener(DocumentResearch.EVENT_DESTROYED, () => {
+      this.disable();
+    });
   }
 
   toggle() {
@@ -202,13 +205,13 @@ export class DocumentController extends ModuleView {
 
   enableView() {
     this.documentResearch.appendTo(this.parentElement);
-    this.documentBrowser.activateWindow(true);
+    this.documentBrowser.appendTo(this.parentElement);
     this.open();
   }
 
   disableView() {
     this.documentResearch.disable();
-    this.documentBrowser.activateWindow(false);
+    this.documentBrowser.disable();
     this.close();
   }
 }

--- a/UDV-Core/src/Modules/ConsultDoc/DocumentController.js
+++ b/UDV-Core/src/Modules/ConsultDoc/DocumentController.js
@@ -62,6 +62,9 @@ export class DocumentController extends ModuleView {
     researchContainer.style = 'display: none;';
     document.getElementById('contentSection').appendChild(researchContainer);
     this.documentResearch = new DocumentResearch(researchContainer, this);
+    this.documentResearch.addEventListener(DocumentResearch.EVENT_DESTROYED, () => {
+      this.disable();
+    });
 
     var browserContainer = document.createElement("div");
     browserContainer.id = this.browserContainerId;
@@ -198,13 +201,13 @@ export class DocumentController extends ModuleView {
   /////// MODULE MANAGEMENT FOR BASE DEMO
 
   enableView() {
-    this.documentResearch.activateWindow(true);
+    this.documentResearch.appendTo(this.parentElement);
     this.documentBrowser.activateWindow(true);
     this.open();
   }
 
   disableView() {
-    this.documentResearch.activateWindow(false);
+    this.documentResearch.disable();
     this.documentBrowser.activateWindow(false);
     this.close();
   }

--- a/UDV-Core/src/Modules/ConsultDoc/DocumentResearch.js
+++ b/UDV-Core/src/Modules/ConsultDoc/DocumentResearch.js
@@ -7,6 +7,7 @@
 
 import $ from 'jquery'; //to use Alpaca
 import 'alpaca';  //provides a simple way to generate HTML forms using jQuery
+import { Window } from '../../Utils/GUI/js/Window';
 
 /**
  *
@@ -15,37 +16,39 @@ import 'alpaca';  //provides a simple way to generate HTML forms using jQuery
  * @param { documentController } documentController
  */
 
-export function DocumentResearch(researchContainer, documentController)
+export class DocumentResearch extends Window
 {
+  constructor(researchContainer, documentController) {
+    super('consultDocSearch', 'Document Research', false);
+
     //Class attributes
     this.documentController = documentController;
     this.researchController = researchContainer;
     this.windowIsActive = false;
 
     this.filterFormId = "filterForm";
+  }
 
+    get innerContentHtml() {
+      return `
+        <div id = "filtersWindow"></div>
+        <div id ="researchWindowTabs">
+          <button id = "docResearch">Search</button>
+        </div>
+      `;
+    }
 
-    /**
-     * Creates the research view
-     */
-    //===========================================================================
-    this.initialize = function initialize()
-    {
-        this.researchController.innerHTML =
-            '<br/><div id = "filtersTitle">Document research</div><br/>\
-            <br/>\
-            <button id = "closeResearch">Close</button>\
-            <div id = "filtersWindow"></div>\
-            <div id ="researchWindowTabs">\
-            <button id = "docResearch">Search</button>\
-            </div>\
-            ';
-
-        this.docModelToSchema();
+    windowCreated() {
+      this.window.style.width = '270px';
+      this.window.style.height = '350px';
+      this.window.style.top = '60px';
+      this.window.style.left = '310px';
+      this.docModelToSchema();
+      this.initializeButtons();
     }
 
     // Display or hide this window
-    this.activateWindow = function activateWindow(active)
+    activateWindow(active)
     {
         if (typeof active != 'undefined')
         {
@@ -65,7 +68,7 @@ export function DocumentResearch(researchContainer, documentController)
 
     }
 
-    this.refresh = function refresh()
+    refresh()
     {
         this.activateWindow(this.windowIsActive);
         //this.documentController.documentBrowser.activateWindow(true);
@@ -75,7 +78,7 @@ export function DocumentResearch(researchContainer, documentController)
      * Launch document research by clicking on the "Search" button
      */
     //=============================================================================
-    this.research = function research()
+    research()
     {
         this.documentController.getDocuments();
         document.getElementById('browserInfo').innerHTML = "The documents have been filtered."
@@ -84,7 +87,7 @@ export function DocumentResearch(researchContainer, documentController)
     }
 
 
-    this.docModelToSchema = function docModelToSchema(){
+    docModelToSchema(){
       //only use the metadata
       var metadata = this.documentController.documentModel.metaData;
       //schema has at least a file input
@@ -167,12 +170,9 @@ export function DocumentResearch(researchContainer, documentController)
      });
    }
 
-
-    this.initialize();
-
     //Event listener for researh button
-    document.getElementById("docResearch").addEventListener('mousedown',
-                                               this.research.bind(this), false);
-    document.getElementById("closeResearch").addEventListener('mousedown',
-                                    this.documentController.disable.bind(this.documentController), false);
+    initializeButtons() {
+      document.getElementById("docResearch").addEventListener('mousedown',
+                                                this.research.bind(this), false);
+    }
 }

--- a/UDV-Core/src/Modules/ConsultDoc/DocumentResearch.js
+++ b/UDV-Core/src/Modules/ConsultDoc/DocumentResearch.js
@@ -42,7 +42,7 @@ export class DocumentResearch extends Window
     windowCreated() {
       this.window.style.width = '270px';
       this.window.style.top = '10px';
-      this.window.style.left = '310px';
+      this.window.style.left = '10px';
       this.docModelToSchema();
       this.initializeButtons();
     }

--- a/UDV-Core/src/Modules/ConsultDoc/DocumentResearch.js
+++ b/UDV-Core/src/Modules/ConsultDoc/DocumentResearch.js
@@ -19,7 +19,7 @@ import { Window } from '../../Utils/GUI/js/Window';
 export class DocumentResearch extends Window
 {
   constructor(researchContainer, documentController) {
-    super('consultDocSearch', 'Document Research', false);
+    super('consultDocSearch', 'Document - Search', false);
 
     //Class attributes
     this.documentController = documentController;

--- a/UDV-Core/src/Modules/ConsultDoc/DocumentResearch.js
+++ b/UDV-Core/src/Modules/ConsultDoc/DocumentResearch.js
@@ -33,6 +33,7 @@ export class DocumentResearch extends Window
       return `
         <div id = "filtersWindow"></div>
         <div id ="researchWindowTabs">
+          <hr>
           <button id = "docResearch">Search</button>
         </div>
       `;
@@ -40,7 +41,6 @@ export class DocumentResearch extends Window
 
     windowCreated() {
       this.window.style.width = '270px';
-      this.window.style.height = '350px';
       this.window.style.top = '10px';
       this.window.style.left = '310px';
       this.docModelToSchema();

--- a/UDV-Core/src/Modules/ConsultDoc/DocumentResearch.js
+++ b/UDV-Core/src/Modules/ConsultDoc/DocumentResearch.js
@@ -41,7 +41,7 @@ export class DocumentResearch extends Window
     windowCreated() {
       this.window.style.width = '270px';
       this.window.style.height = '350px';
-      this.window.style.top = '60px';
+      this.window.style.top = '10px';
       this.window.style.left = '310px';
       this.docModelToSchema();
       this.initializeButtons();

--- a/UDV-Core/src/Modules/ConsultDoc/DocumentResearch.js
+++ b/UDV-Core/src/Modules/ConsultDoc/DocumentResearch.js
@@ -82,7 +82,6 @@ export class DocumentResearch extends Window
     {
         this.documentController.getDocuments();
         document.getElementById('browserInfo').innerHTML = "The documents have been filtered."
-        this.documentController.documentBrowser.activateWindow(true);
         this.documentController.documentBrowser.updateBrowser();
     }
 

--- a/UDV-Core/src/Modules/GuidedTour/GuidedTour.css
+++ b/UDV-Core/src/Modules/GuidedTour/GuidedTour.css
@@ -1,6 +1,5 @@
 #guidedTourTab{
     position: absolute;
-    z-index: 40;
     margin : 3px;
     border: 1px solid black;
     background-color: white;
@@ -12,20 +11,10 @@
 }
 
 #guidedTourWindow{
-    display: none;
-    position: absolute;
-    z-index: 10;
-    margin : 3px;
-    margin-right: 0px;
-    top: 30px;
-    left: 0;
-    border : 1px solid rgb(90,90,90);
+    position: relative;
     text-align: center;
-    color: white;
-    width: 22%;
-    height: 65%;
     color : black;
-    background-color: rgba(30,30,30,0.6);
+    height: 100%;
     font-size: 14;
     pointer-events: none;
 }
@@ -94,7 +83,6 @@
 }
 
 #guidedTourDocPreview{
-    z-index: 20;
     height: 25%;
     display:inline-block;
     margin: 5% ;
@@ -108,7 +96,6 @@
 
 #guidedTourStartButton{
     position: absolute;
-    z-index: 20;
     bottom : 5px;
     left: 0;
     right: 0;
@@ -123,7 +110,6 @@
 
 #guidedTourNextTourButton{
     position: absolute;
-    z-index: 20;
     bottom : 5px;
     right: 5px;
     margin: auto;
@@ -137,7 +123,6 @@
 
 #guidedTourPreviousTourButton{
     position: absolute;
-    z-index: 20;
     bottom : 5px;
     left : 5px;
     margin : auto;
@@ -151,7 +136,6 @@
 
 #guidedTourNextStepButton{
     position: absolute;
-    z-index: 20;
     bottom : 5px;
     right: 5px;
     margin: auto;
@@ -165,7 +149,6 @@
 
 #guidedTourPreviousStepButton{
     position: absolute;
-    z-index: 20;
     bottom : 5px;
     left : 5px;
     margin : auto;
@@ -179,7 +162,6 @@
 
 #guidedTourExitButton{
     position: absolute;
-    z-index: 20;
     display:none;
     bottom : 5px;
     left: 0;

--- a/UDV-Core/src/Modules/GuidedTour/GuidedTour.js
+++ b/UDV-Core/src/Modules/GuidedTour/GuidedTour.js
@@ -108,7 +108,7 @@ export class GuidedTour extends Window {
     document.getElementById("guidedTourPreviousStepButton").style.display = "none";
     document.getElementById("guidedTourNextStepButton").style.display = "none";
     document.getElementById("guidedTourExitButton").style.display = "none";
-    document.getElementById("guidedTourText2").style.display = "none";
+    //document.getElementById("guidedTourText2").style.display = "none";
     document.getElementById("guidedTourStartButton").style.display = "block";
 
     document.getElementById('guidedTourTitle').innerHTML =
@@ -117,10 +117,6 @@ export class GuidedTour extends Window {
                            this.guidedTourController.getCurrentTour().description;
     document.getElementById("guidedTourText1").style.height = "45%";
     document.getElementById("guidedTourStepTitle").innerHTML = null;
-
-    document.getElementById('docHead').style.display = "none";
-    document.getElementById('resetFilters').style.display = "none";
-    document.getElementById('docBrowserInfo').style.display = "none";
 
   }
 
@@ -136,7 +132,6 @@ export class GuidedTour extends Window {
     this.documentBrowser.updateBrowser();
     document.getElementById("guidedTourText1").innerHTML = this.currentStep.text1;
     document.getElementById('guidedTourStepTitle').innerHTML = this.currentStep.title;
-    document.getElementById("guidedTourText2").innerHTML = this.currentStep.text2;
     this.documentBrowser.focusOnDoc();
   }
 
@@ -150,13 +145,12 @@ export class GuidedTour extends Window {
       this.updateStep();
       // setup the display (hide & show elements)
       this.guidedTourController.toggleGuidedTourButtons(false);
-      document.getElementById("guidedTourText2").style.display = "inline-block";
       document.getElementById("guidedTourDocPreviewImg").style.display = "none";
       document.getElementById("guidedTourText1").style.height = "60%";
-      document.getElementById('docBrowserWindow').style.display = "block";
+      /*
       document.getElementById('docBrowserPreviousButton').style.display = "none";
       document.getElementById('docBrowserNextButton').style.display = "none";
-      document.getElementById('docBrowserIndex').style.display = "none";
+      document.getElementById('docBrowserIndex').style.display = "none";*/
       document.getElementById('tourCpt').style.display = "none";
     }
     else {
@@ -171,9 +165,10 @@ export class GuidedTour extends Window {
 
       this.guidedTourController.reset();
       // show the regular buttons for doc window
+      /*
       document.getElementById('docBrowserPreviousButton').style.display = "block";
       document.getElementById('docBrowserNextButton').style.display = "block";
-      document.getElementById('docBrowserIndex').style.display = "block";
+      document.getElementById('docBrowserIndex').style.display = "block";*/
   };
 
   /**

--- a/UDV-Core/src/Modules/GuidedTour/GuidedTour.js
+++ b/UDV-Core/src/Modules/GuidedTour/GuidedTour.js
@@ -1,4 +1,6 @@
 import './GuidedTour.css'
+import { Window } from '../../Utils/GUI/js/Window';
+import '../../Utils/GUI/css/window.css';
 
 /**
  * Class: GuidedTour
@@ -10,51 +12,64 @@ import './GuidedTour.css'
  * @param { guidedTourController } guidedTourController : instance of GuidedTourController
  *
 //=============================================================================*/
-export function GuidedTour(guidedTourContainer, guidedTourController) {
+export class GuidedTour extends Window {
 
-  this.guidedTourController = guidedTourController;
+  constructor(guidedTourController) {
+    super('guidedTour', 'Guided Tour', false)
+    this.guidedTourController = guidedTourController;
 
-  this.tourIndex = 1; //current guided tour. Default is 1 (start)
+    this.tourIndex = 1; //current guided tour. Default is 1 (start)
 
-  this.stepIndex = 1; //current step of the guidedtour. Defautt is 1 (start)
+    this.stepIndex = 1; //current step of the guidedtour. Defautt is 1 (start)
 
-  // boolean to control the state of the guided tour window (open/closed)
-  this.guidedTourWindowIsActive = true;
+    // boolean to control the state of the guided tour window (open/closed)
+    this.guidedTourWindowIsActive = true;
 
-  this.isStart = true;
+    this.isStart = true;
 
-  this.currentTour = null; //current guided tour
-  this.currentStep = null; //current step of the current guided tour
+    this.currentTour = null; //current guided tour
+    this.currentStep = null; //current step of the current guided tour
 
-  //instance of document browser
-  this.documentBrowser = this.guidedTourController.browser;
+    //instance of document browser
+    this.documentBrowser = this.guidedTourController.browser;
 
-  // update the html with elements for this class (windows, buttons etc)
-  guidedTourContainer.innerHTML = '\
-  <button id="guidedTourTab">EXPLORE</button>\
-  <div id="guidedTourWindow">\
-  <div id="guidedTourTitle"></div>\
-  <div id="guidedTourStepTitle"></div>\
-  <div id="guidedTourText1"></div>\
-  <div id="guidedTourDocPreview"><img id="guidedTourDocPreviewImg"/></div>\
-  <div id="tourCpt"></div>\
-  <button id="guidedTourNextStepButton" type=button>⇨</button>\
-  <button id="guidedTourNextTourButton" type=button>⇨</button>\
-  <button id="guidedTourPreviousStepButton" type=button>⇦</button>\
-  <button id="guidedTourPreviousTourButton" type=button>⇦</button>\
-  <button id="guidedTourExitButton" type=button>EXIT</button>\
-  <button id="guidedTourStartButton" type=button>START</button>\
-  </div>\
-  ';
+    //update browser view
+    var guidedTourText2 = document.createElement('div');
+    guidedTourText2.id = 'guidedTourText2';
+    document.getElementById('docBrowserWindow').appendChild(guidedTourText2);
+  }
 
-  //update browser view
-  var guidedTourText2 = document.createElement('div');
-  guidedTourText2.id = 'guidedTourText2';
-  document.getElementById('docBrowserWindow').appendChild(guidedTourText2);
+  get innerContentHtml() {
+    return `
+    <div id="guidedTourWindow">
+    <div id="guidedTourTitle"></div>
+    <div id="guidedTourStepTitle"></div>
+    <div id="guidedTourText1"></div>
+    <div id="guidedTourDocPreview"><img id="guidedTourDocPreviewImg"/></div>
+    <div id="tourCpt"></div>
+    <button id="guidedTourNextStepButton" type=button>⇨</button>
+    <button id="guidedTourNextTourButton" type=button>⇨</button>
+    <button id="guidedTourPreviousStepButton" type=button>⇦</button>
+    <button id="guidedTourPreviousTourButton" type=button>⇦</button>
+    <button id="guidedTourExitButton" type=button>EXIT</button>
+    <button id="guidedTourStartButton" type=button>START</button>
+    </div>
+    `;
+  }
+
+  windowCreated() {
+    this.initializeButtons();
+    this.startGuidedTourMode();
+    this.window.style.width = '500px';
+    this.window.style.height = '500px';
+    this.window.style.top = '60px';
+    this.window.style.left = '310px';
+    this.innerContent.style.height = '100%';
+  }
 
   // hide or show the guided tour window
   //=============================================================================
-  this.toggleGuidedTourWindow = function toggleGuidedTourWindow(){
+  toggleGuidedTourWindow(){
 
     document.getElementById('guidedTourWindow').style.display =
                                 this.guidedTourWindowIsActive ? "block" : "none";
@@ -68,7 +83,7 @@ export function GuidedTour(guidedTourContainer, guidedTourController) {
   }
 
   //get all available guided tour from the database
-  this.startGuidedTourMode = function startGuidedTourMode(){
+  startGuidedTourMode(){
     this.guidedTourController.getGuidedTours();
     this.previewTour();
 
@@ -78,7 +93,7 @@ export function GuidedTour(guidedTourContainer, guidedTourController) {
    * Initialize the preview of the guided tour
    */
   //=============================================================================
-  this.previewTour = function previewTour(){
+  previewTour(){
     document.getElementById('tourCpt').innerHTML = "Tour: "
       + this.tourIndex + " out of " + this.guidedTourController.guidedTours.length;
     document.getElementById("guidedTourPreviousTourButton").style.display = "block";
@@ -112,7 +127,7 @@ export function GuidedTour(guidedTourContainer, guidedTourController) {
 
   // update step with current step data
   //=============================================================================
-  this.updateStep = function updateStep(){
+  updateStep(){
 
     this.currentStep = this.guidedTourController.getCurrentStep();
     this.documentBrowser.currentMetadata =
@@ -127,7 +142,7 @@ export function GuidedTour(guidedTourContainer, guidedTourController) {
 
   //start guided tour
   //=============================================================================
-  this.startGuidedTour = function startGuidedTour(){
+  startGuidedTour(){
 
     if(this.guidedTourController.getCurrentTour().extendedDocs.length > 0){
       this.tourIndex = 1;
@@ -152,7 +167,7 @@ export function GuidedTour(guidedTourContainer, guidedTourController) {
 
   // Quit current guided tour
   //=============================================================================
-  this.exitGuidedTour = function exitGuidedTour(){
+  exitGuidedTour(){
 
       this.guidedTourController.reset();
       // show the regular buttons for doc window
@@ -165,7 +180,7 @@ export function GuidedTour(guidedTourContainer, guidedTourController) {
    * Update guided tour preview by clicking on "guidedTourNextTourButton" button
    */
   //=============================================================================
-  this.nextTour = function nextTour(){
+  nextTour(){
     if(this.tourIndex < this.guidedTourController.guidedTours.length){
       this.guidedTourController.getNextTour();
       this.tourIndex ++;
@@ -177,7 +192,7 @@ export function GuidedTour(guidedTourContainer, guidedTourController) {
    * Update guided tour preview by clicking on "guidedTourPreviousTourButton" button
    */
   //=============================================================================
-  this.previousTour = function previousTour(){
+  previousTour(){
     this.guidedTourController.getPreviousTour();
     if(this.tourIndex > 1 ){
       this.tourIndex --;
@@ -189,7 +204,7 @@ export function GuidedTour(guidedTourContainer, guidedTourController) {
    * Update step by clicking on "guidedTourNextStepButton" button
    */
   //=============================================================================
-  this.nextStep = function nextStep(){
+  nextStep(){
 
     if(this.stepIndex < this.guidedTourController.getCurrentTour().extendedDocs.length ){
       this.stepIndex ++;
@@ -203,7 +218,7 @@ export function GuidedTour(guidedTourContainer, guidedTourController) {
    * Update step by clicking on "guidedTourPreviousStepButton" button
    */
   //=============================================================================
-  this.previousStep = function previousStep(){
+  previousStep(){
 
     if( this.stepIndex > 1 ){
       this.guidedTourController.getPreviousStep();
@@ -213,19 +228,19 @@ export function GuidedTour(guidedTourContainer, guidedTourController) {
   }
 
   // event listeners (buttons)
-  document.getElementById("guidedTourNextTourButton").addEventListener('mousedown',
-                                                this.nextTour.bind(this),false);
-  document.getElementById("guidedTourPreviousTourButton").addEventListener('mousedown',
-                                            this.previousTour.bind(this),false);
-  document.getElementById("guidedTourStartButton").addEventListener('mousedown',
-                                         this.startGuidedTour.bind(this),false);
-  document.getElementById("guidedTourNextStepButton").addEventListener('mousedown',
-                                                this.nextStep.bind(this),false);
-  document.getElementById("guidedTourPreviousStepButton").addEventListener('mousedown',
-                                            this.previousStep.bind(this),false);
-  document.getElementById("guidedTourExitButton").addEventListener('mousedown',
-                                          this.exitGuidedTour.bind(this),false);
-  document.getElementById("guidedTourTab").addEventListener('mousedown',
-                                 this.toggleGuidedTourWindow.bind(this), false);
+  initializeButtons() {
+    document.getElementById("guidedTourNextTourButton").addEventListener('mousedown',
+                                                  this.nextTour.bind(this),false);
+    document.getElementById("guidedTourPreviousTourButton").addEventListener('mousedown',
+                                              this.previousTour.bind(this),false);
+    document.getElementById("guidedTourStartButton").addEventListener('mousedown',
+                                          this.startGuidedTour.bind(this),false);
+    document.getElementById("guidedTourNextStepButton").addEventListener('mousedown',
+                                                  this.nextStep.bind(this),false);
+    document.getElementById("guidedTourPreviousStepButton").addEventListener('mousedown',
+                                              this.previousStep.bind(this),false);
+    document.getElementById("guidedTourExitButton").addEventListener('mousedown',
+                                            this.exitGuidedTour.bind(this),false);
+  }
 
 }

--- a/UDV-Core/src/Modules/GuidedTour/GuidedTour.js
+++ b/UDV-Core/src/Modules/GuidedTour/GuidedTour.js
@@ -36,7 +36,7 @@ export class GuidedTour extends Window {
     //update browser view
     var guidedTourText2 = document.createElement('div');
     guidedTourText2.id = 'guidedTourText2';
-    //document.getElementById('docBrowserWindow').appendChild(guidedTourText2);
+    document.getElementById('docBrowserWindow').appendChild(guidedTourText2);
   }
 
   get innerContentHtml() {

--- a/UDV-Core/src/Modules/GuidedTour/GuidedTour.js
+++ b/UDV-Core/src/Modules/GuidedTour/GuidedTour.js
@@ -36,7 +36,7 @@ export class GuidedTour extends Window {
     //update browser view
     var guidedTourText2 = document.createElement('div');
     guidedTourText2.id = 'guidedTourText2';
-    document.getElementById('docBrowserWindow').appendChild(guidedTourText2);
+    //document.getElementById('docBrowserWindow').appendChild(guidedTourText2);
   }
 
   get innerContentHtml() {

--- a/UDV-Core/src/Modules/GuidedTour/GuidedTour.js
+++ b/UDV-Core/src/Modules/GuidedTour/GuidedTour.js
@@ -62,7 +62,7 @@ export class GuidedTour extends Window {
     this.startGuidedTourMode();
     this.window.style.width = '500px';
     this.window.style.height = '500px';
-    this.window.style.top = '60px';
+    this.window.style.top = '10px';
     this.window.style.left = '310px';
     this.innerContent.style.height = '100%';
   }

--- a/UDV-Core/src/Modules/GuidedTour/GuidedTour.js
+++ b/UDV-Core/src/Modules/GuidedTour/GuidedTour.js
@@ -60,10 +60,10 @@ export class GuidedTour extends Window {
   windowCreated() {
     this.initializeButtons();
     this.startGuidedTourMode();
-    this.window.style.width = '500px';
-    this.window.style.height = '500px';
-    this.window.style.top = '10px';
-    this.window.style.left = '310px';
+    this.window.style.width = '440px';
+    this.window.style.height = '470px';
+    this.window.style.top = '375px';
+    this.window.style.left = '10px';
     this.innerContent.style.height = '100%';
   }
 

--- a/UDV-Core/src/Modules/GuidedTour/GuidedTour.js
+++ b/UDV-Core/src/Modules/GuidedTour/GuidedTour.js
@@ -147,10 +147,6 @@ export class GuidedTour extends Window {
       this.guidedTourController.toggleGuidedTourButtons(false);
       document.getElementById("guidedTourDocPreviewImg").style.display = "none";
       document.getElementById("guidedTourText1").style.height = "60%";
-      /*
-      document.getElementById('docBrowserPreviousButton').style.display = "none";
-      document.getElementById('docBrowserNextButton').style.display = "none";
-      document.getElementById('docBrowserIndex').style.display = "none";*/
       document.getElementById('tourCpt').style.display = "none";
     }
     else {
@@ -162,13 +158,7 @@ export class GuidedTour extends Window {
   // Quit current guided tour
   //=============================================================================
   exitGuidedTour(){
-
       this.guidedTourController.reset();
-      // show the regular buttons for doc window
-      /*
-      document.getElementById('docBrowserPreviousButton').style.display = "block";
-      document.getElementById('docBrowserNextButton').style.display = "block";
-      document.getElementById('docBrowserIndex').style.display = "block";*/
   };
 
   /**

--- a/UDV-Core/src/Modules/GuidedTour/GuidedTourController.js
+++ b/UDV-Core/src/Modules/GuidedTour/GuidedTourController.js
@@ -158,8 +158,6 @@ export class GuidedTourController extends ModuleView {
     this.currentTourIndex = 0;
     this.currentGuidedTour = this.guidedTours[this.currentTourIndex];
     this.guidedTour.currentStep = this.getCurrentStep();
-    this.documentController.documentBrowser.activateWindow(false);
-    this.documentController.documentBrowser.closeDocFull();
     this.guidedTour.previewTour();
 
   }

--- a/UDV-Core/src/Modules/GuidedTour/GuidedTourController.js
+++ b/UDV-Core/src/Modules/GuidedTour/GuidedTourController.js
@@ -59,10 +59,10 @@ export class GuidedTourController extends ModuleView {
   */
   //=============================================================================
   initialize() {
-    var guidedTourContainer = document.createElement("div");
-    guidedTourContainer.id = this.guidedTourContainerId;
-    document.body.appendChild(guidedTourContainer);
-    this.guidedTour = new GuidedTour(guidedTourContainer, this);
+    this.guidedTour = new GuidedTour(this);
+    this.guidedTour.addEventListener(GuidedTour.EVENT_DESTROYED, () => {
+      this.disable();
+    });
   }
 
   /**
@@ -179,11 +179,11 @@ export class GuidedTourController extends ModuleView {
   /////// MODULE MANAGEMENT FOR BASE DEMO
 
   enableView() {
-    document.getElementById(this.guidedTourContainerId).style.setProperty('display', 'block');
+    this.guidedTour.appendTo(this.parentElement);
   }
 
   disableView() {
-    document.getElementById(this.guidedTourContainerId).style.setProperty('display', 'none');
+    this.guidedTour.dispose();
   }
 
 }

--- a/UDV-Core/src/Modules/Others/About.css
+++ b/UDV-Core/src/Modules/Others/About.css
@@ -1,7 +1,7 @@
 
 #aboutWindow {
     position: absolute;
-    top: 50px;
+    top: 10px;
     width: 15%;
     right : 22.5%;
     color: white;

--- a/UDV-Core/src/Modules/Others/Compass.js
+++ b/UDV-Core/src/Modules/Others/Compass.js
@@ -18,7 +18,7 @@ export function CompassController(controls) {
     //update the html with elements for this class (compass image)
     var compassDiv = document.createElement("div");
     compassDiv.id = 'compass';
-    document.body.appendChild(compassDiv);
+    document.getElementById('viewerDiv').appendChild(compassDiv);
 
     document.getElementById("compass").innerHTML = '\
     <div id="compassWindow">\

--- a/UDV-Core/src/Modules/Others/Help.css
+++ b/UDV-Core/src/Modules/Others/Help.css
@@ -1,7 +1,7 @@
 #helpWindow {
     position: absolute;
     width: 15%;
-    top: 50px;
+    top: 10px;
     left : 22.5%;
     color: white;
     font-size: 75%;

--- a/UDV-Core/src/Modules/Others/MiniMap.js
+++ b/UDV-Core/src/Modules/Others/MiniMap.js
@@ -19,7 +19,7 @@ export function MiniMapController(controls, extent, renderer) {
     //update the html with elements for this class (windows, buttons etc)
     var miniMapDiv = document.createElement("div");
     miniMapDiv.id = 'minimap';
-    document.body.appendChild(miniMapDiv);
+    document.getElementById('viewerDiv').appendChild(miniMapDiv);
 
     document.getElementById("minimap").innerHTML =
       '<button   id="miniMapTab">Minimap</button>\

--- a/UDV-Core/src/Modules/Temporal/Temporal.css
+++ b/UDV-Core/src/Modules/Temporal/Temporal.css
@@ -10,7 +10,7 @@
 
     margin: auto;
 
-    bottom : 0;
+    bottom : 5px;
     left : 0;
     right : 0;
 

--- a/UDV-Core/src/Utils/BaseDemo/css/Demo.css
+++ b/UDV-Core/src/Utils/BaseDemo/css/Demo.css
@@ -137,6 +137,8 @@ section {
     color: white;
     visibility: hidden;
     opacity: 0;
+    text-shadow: 1px 1px 1px #0009;
+    box-shadow: 1px 0px 1px -1px #0009, 0px 1px 1px -1px #0009, 0px -1px 1px -1px #0009;
 }
 
 .choiceMenu:hover > ._base_demo_menu_hint {

--- a/UDV-Core/src/Utils/BaseDemo/css/Demo.css
+++ b/UDV-Core/src/Utils/BaseDemo/css/Demo.css
@@ -2,6 +2,10 @@ a {
     color : lightgreen;
 }
 
+* {
+    z-index: inherit;
+}
+
 html {
     font-family: sans-serif;
     font-size: 14px;
@@ -12,37 +16,46 @@ html {
 body {
     margin: 0;
     background-color: black;
-    overflow: hidden;
     height: 100%;
-}
-
-button:hover {
-    cursor: pointer;
 }
 
 #viewerDiv {
-    width: 100%;
     height: 100%;
+    position: relative;
+}
+
+canvas {
     position: absolute;
-    top: 50px;
-    left: 0;
-    margin : auto auto;
-    padding: 0;
+}
+
+#_base_demo {
+    display: grid;
+    height: 100%;
+    grid-template-rows: 50px auto;
 }
 
 header {
-    display: block;
-    z-index: 10000;
+    background-color: #333333;
 }
 
-.header {
-    z-index: inherit;
-    position: fixed;
-    display: flex;
-    flex-direction: row-reverse;
-    height: 50px;
-    width: 100%;
-    background-color: #333333;
+header * {
+    vertical-align: top;
+}
+
+#_base_demo_stuct_main_panel {
+    display: grid;
+    grid-template-columns: 60px auto;
+}
+
+nav {
+    background-color: #222222;
+    display: inline-block;
+    height: 100%;
+    z-index: 50001;
+}
+
+section {
+    height: 100%;
 }
 
 #openSidebar {
@@ -54,73 +67,39 @@ header {
     margin: 5px 10px 5px 5px;
 }
 
-#openHamburger, #closeHamburger {
-    z-index: inherit;
-    margin: 0 10px;
-    box-sizing: border-box;
-    position: absolute;
-    font-size: 35px;
-    color: white;
-    top: 0;
-    left: 0;
-}
-
 .choiceMenu:hover, #openSidebar:hover, #openHamburger:hover, #closeHamburger:hover {
     cursor: pointer;
 }
 
-#_base_demo_menu {
-    z-index: 10002;
-    position: fixed;
-    left: 0;
-    height: 100%;
-    width: 300px;
-    transform: translateX(-300px);
-    transition: transform 250ms ease-in-out;
-    background-color: #2c2c2c;
-}
-
-#navMenu {
-    height: 50px;
-    width: 100%;
-    background-color: #1e1e1e;
+#_base_demo_auth_frame_location {
+    display: inline-block;
 }
 
 #_base_demo_profile {
-    position: relative;
-    min-height: 80px;
-    background-color: black;
-    margin-bottom: 20px;
-    text-align: center;
-}
-
-#profileIcon {
-    width: 100px;
-    margin: 15px 10px 5px;
+    
 }
 
 #_base_demo_profile_name {
-    box-sizing: border-box;
+    display: inline-block;
     color: white;
-    padding: 5px 15px;
-    font-size: 25px;
-    width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    font-size: 20px;
+    padding: 10px;
+}
+
+#_base_demo_profile_name em {
+    font-style: normal;
+    font-weight: bold;
 }
 
 .logInOut {
-    position: relative;
-    bottom: 0;
-    width: 50%;
-    font-size: 24px;
-    border-radius: 10px;
-    margin: 20px auto;
-    text-align: center;
-    color: white;
-    background-color: #333333;
-    border: 2px solid gray;
-    height: 33px;
+    display: inline-block;
+    border: 0;
+    background: 0;
+    color : lightgreen;
+    padding: 11px;
+    font-size: 18px;
+    text-decoration: underline;
+    font-style: italic;
 }
 
 #loginRegistration {
@@ -131,20 +110,57 @@ header {
     cursor: pointer;
 }
 
-.choiceMenu {
-    display: flex;
-    flex-wrap: nowrap;
-    vertical-align: middle;
-    color: white;
-    font-size: 25px;
-    border-radius: 5px;
-    margin: 10px;
-    padding: 10px 0;
+#_base_demo_menu {
+    list-style: none;
+    padding: 0;
 }
 
-.choiceMenuSelected, #activateTemporal:checked ~ header #temporalMenu {
+.choiceMenu {
+    position: relative;
+    height: 60px;
+}
+
+._base_demo_menu_hint {
+    position: absolute;
+    background-color: #666666;
+    z-index: 50000;
+    height: 100%;
+    padding: 20px;
+    padding-top: 12px;
+    font-size: 24px;
+    display: inline-block;
+    margin: 0;
+    left: 100%;
+    top: 0;
+    white-space: nowrap;
+    box-sizing: border-box;
+    color: white;
+    visibility: hidden;
+    opacity: 0;
+}
+
+.choiceMenu:hover > ._base_demo_menu_hint {
+    visibility: visible;
+    opacity: 1;
+}
+
+.choiceMenuSelected > ._base_demo_menu_hint {
+    background-color: #35a2ff;
+}
+
+#activateTemporal:checked ~ header #temporalMenu {
     background-color: rgba(255, 255, 255, 0.1);
-    box-shadow: inset 0px 0px 10px 0px rgb(0, 0, 0);
+}
+
+.choiceMenuSelected::after {
+    position: absolute;
+    height: 100%;
+    right: 0;
+    top: 0;
+    width: 5px;
+    background-color: #35a2ff;;
+    content: "";
+    z-index: inherit;
 }
 
 .nonVisible{
@@ -152,14 +168,13 @@ header {
 }
 
 #_base_demo_menu .choiceMenu:hover {
-    cursor: pointer;
-    background-color: rgba(255, 255, 255, 0.2);
+    background-color: #666666;
 }
 
 .menuIcon {
     display: inline-block;
-    width: 30px;
-    margin: 0 20px 0 10px;
+    width: 36px;
+    margin: 12px 12px 12px 12px;
     flex-shrink: 0;
 }
 
@@ -172,7 +187,7 @@ header {
     display: none;
 }
 
-#activateTemporal:checked ~ #contentSection #temporal {
+#activateTemporal:checked ~ #temporal {
     display: block;
 }
 

--- a/UDV-Core/src/Utils/BaseDemo/css/Demo.css
+++ b/UDV-Core/src/Utils/BaseDemo/css/Demo.css
@@ -32,13 +32,14 @@ button:hover {
 
 header {
     display: block;
+    z-index: 10000;
 }
 
 .header {
+    z-index: inherit;
     position: fixed;
     display: flex;
     flex-direction: row-reverse;
-    z-index: 11;
     height: 50px;
     width: 100%;
     background-color: #333333;
@@ -54,12 +55,12 @@ header {
 }
 
 #openHamburger, #closeHamburger {
+    z-index: inherit;
     margin: 0 10px;
     box-sizing: border-box;
     position: absolute;
     font-size: 35px;
     color: white;
-    z-index: 11;
     top: 0;
     left: 0;
 }
@@ -69,11 +70,11 @@ header {
 }
 
 #_base_demo_menu {
+    z-index: 10002;
     position: fixed;
     left: 0;
     height: 100%;
     width: 300px;
-    z-index: 12;
     transform: translateX(-300px);
     transition: transform 250ms ease-in-out;
     background-color: #2c2c2c;

--- a/UDV-Core/src/Utils/BaseDemo/css/Demo.css
+++ b/UDV-Core/src/Utils/BaseDemo/css/Demo.css
@@ -63,6 +63,7 @@ nav {
 }
 
 section {
+    position: relative;
     height: 100%;
 }
 

--- a/UDV-Core/src/Utils/BaseDemo/css/Demo.css
+++ b/UDV-Core/src/Utils/BaseDemo/css/Demo.css
@@ -45,6 +45,14 @@ header * {
     vertical-align: top;
 }
 
+header h1 {
+    display: inline-block;
+    color: white;
+    margin: 5px;
+    font-size: 28px;
+    height: 100%;
+}
+
 #_base_demo_struct_header_panel {
     text-align: right;
     padding-right: 10px;

--- a/UDV-Core/src/Utils/BaseDemo/css/Demo.css
+++ b/UDV-Core/src/Utils/BaseDemo/css/Demo.css
@@ -11,6 +11,7 @@ html {
     font-size: 14px;
     height: 100%;
     width: 100%;
+    overflow: hidden;
 }
 
 body {
@@ -36,10 +37,17 @@ canvas {
 
 header {
     background-color: #333333;
+    display: grid;
+    grid-template-columns: auto auto;
 }
 
 header * {
     vertical-align: top;
+}
+
+#_base_demo_struct_header_panel {
+    text-align: right;
+    padding-right: 10px;
 }
 
 #_base_demo_stuct_main_panel {
@@ -89,6 +97,7 @@ section {
 #_base_demo_profile_name em {
     font-style: normal;
     font-weight: bold;
+    font-variant: small-caps;
 }
 
 .logInOut {
@@ -147,7 +156,7 @@ section {
 }
 
 .choiceMenuSelected > ._base_demo_menu_hint {
-    background-color: #35a2ff;
+    background-color: #f09f45;
 }
 
 #activateTemporal:checked ~ header #temporalMenu {
@@ -160,7 +169,7 @@ section {
     right: 0;
     top: 0;
     width: 5px;
-    background-color: #35a2ff;;
+    background-color: #f09f45;
     content: "";
     z-index: inherit;
 }
@@ -178,6 +187,7 @@ section {
     width: 36px;
     margin: 12px 12px 12px 12px;
     flex-shrink: 0;
+    opacity: 0.9;
 }
 
 #openSidebar:checked ~ #_base_demo_menu {

--- a/UDV-Core/src/Utils/BaseDemo/js/BaseDemo.js
+++ b/UDV-Core/src/Utils/BaseDemo/js/BaseDemo.js
@@ -36,35 +36,32 @@ export class BaseDemo {
      */
     get html() {
         return /*html*/`
-            <input type="checkbox" id="activateTemporal" class="nonVisible">
-            <header>
-                <div class="header">
-                    <div>
-                        Icons made by <a href="https://www.freepik.com/"
-                        title="Freepik">Freepik</a> from
-                        <a href="https://www.flaticon.com/"
-                        title="Flaticon">www.flaticon.com</a> is licensed by
-                        <a href="http://creativecommons.org/licenses/by/3.0/"
-                        title="Creative Commons BY 3.0" target="_blank">
-                        CC 3.0 BY</a>
-                    </div>
-                    <img id="logoIMU" src="${this.imageFolder}/${this.logoIMUFile}" />
-                    <img id="logoLIRIS" src="${this.imageFolder}/${this.logoLIRISFile}" />
-                </div>
-                <input type="checkbox" id="openSidebar">
-                <!-- The HTML code corresponds to an hamburger menu icon -->
-                <label id="closeHamburger" for="openSidebar">&#x2630</label>
-                <div id="${this.menuId}">
-                    <div id="navMenu"></div>
-                    <!-- This one corresponds to a cross icon -->
-                    <label id="openHamburger" for="openSidebar">&#x2716</label>
-                    <label for="activateTemporal" id="temporalMenu"
-                    class="choiceMenu">Temporal</label>
-                </div>
+            <header id="${this.headerId}">
+                <div id="${this.authFrameLocationId}"></div>
+                <img id="logoIMU" src="${this.imageFolder}/${this.logoIMUFile}" />
+                <img id="logoLIRIS" src="${this.imageFolder}/${this.logoLIRISFile}" />
+                <p style="display: inline-block; color: white;">
+                    Icons made by <a href="https://www.freepik.com/"
+                    title="Freepik">Freepik</a> from
+                    <a href="https://www.flaticon.com/"
+                    title="Flaticon">www.flaticon.com</a> is licensed by
+                    <a href="http://creativecommons.org/licenses/by/3.0/"
+                    title="Creative Commons BY 3.0" target="_blank">
+                    CC 3.0 BY</a>
+                </p>
             </header>
-            <section id="${this.contentSectionId}">
-                <div id="${this.viewerDivId}"></div>
-            </section>
+            <div id="_base_demo_stuct_main_panel">
+                <nav>
+                    <ul id="${this.menuId}">
+                        <li class="choiceMenu" id="temporalMenu">
+                            <p class="_base_demo_menu_hint">Temporal</p>
+                        </li>
+                    </ul>
+                </nav>
+                <section id="${this.contentSectionId}">
+                    <div id="${this.viewerDivId}"></div>
+                </section>
+            </div>
         `;
     }
 
@@ -76,7 +73,6 @@ export class BaseDemo {
     get authenticationFrameHtml() {
         return /*html*/`
             <div id="${this.authenticationMenuLoggedInId}">
-                <img src="${this.iconFolder}/profile.svg" id="profileIcon">
                 <div id="${this.authenticationUserNameId}"></div>
                 <button type="button" id="${this.authenticationLogoutButtonId}"
                 class="logInOut">Logout</button>
@@ -208,9 +204,9 @@ export class BaseDemo {
      * @param {String} [accessKey] The key binding for the module.
      */
     createMenuButton(moduleId, buttonText, accessKey) {
-        let button = document.createElement('label');
+        let button = document.createElement('li');
         button.id = this.getModuleButtonId(moduleId);
-        button.innerText = buttonText;
+        button.innerHTML = `<p class="_base_demo_menu_hint">${buttonText}</p>`;
         if (!!accessKey) {
             button.accessKey = accessKey;
         }
@@ -248,8 +244,7 @@ export class BaseDemo {
         let frame = document.createElement('div');
         frame.id = this.authenticationFrameId;
         frame.innerHTML = this.authenticationFrameHtml;
-        this.menuElement.insertBefore(frame,
-            document.getElementById('openHamburger').nextSibling);
+        this.authFrameLocationElement.appendChild(frame);
         const authView = this.getModuleById(authModuleId);
         authView.parentElement = this.viewerDivElement;
         const authService = authView.authenticationService;
@@ -289,7 +284,7 @@ export class BaseDemo {
                 this.authenticationMenuLoggedInElement.hidden = false;
                 this.authenticationMenuLoggedOutElement.hidden = true;
                 this.authenticationUserNameElement.innerHTML =
-                    `${user.firstname} ${user.lastname}`;
+                    `Logged in as <em>${user.firstname} ${user.lastname}</em>`;
                 for (let mid of this.requireAuthModules) {
                     this.getModuleButton(mid).style.removeProperty('display');
                 }
@@ -418,6 +413,17 @@ export class BaseDemo {
             });
 
         let temporalButton = document.getElementById('temporalMenu');
+        temporalButton.onclick = () => {
+            let tmp = document.getElementById('temporal');
+            let disp = window.getComputedStyle(tmp).display;
+            if (disp === 'none') {
+                tmp.style.display = 'block';
+                temporalButton.className = 'choiceMenu choiceMenuSelected';
+            } else {
+                tmp.style.display = 'none';
+                temporalButton.className = 'choiceMenu';
+            }
+        }
         //creating an icon
         let icon = document.createElement('img');
         icon.setAttribute('src', `${this.iconFolder}/temporal.svg`)
@@ -490,6 +496,22 @@ export class BaseDemo {
 
     get mainDivId() {
         return '_base_demo';
+    }
+
+    get headerId() {
+        return '_base_demo_header';
+    }
+
+    get headerElement() {
+        return document.getElementById(this.headerId);
+    }
+
+    get authFrameLocationId() {
+        return '_base_demo_auth_frame_location';
+    }
+
+    get authFrameLocationElement() {
+        return document.getElementById(this.authFrameLocationId);
     }
 
     get contentSectionId() {

--- a/UDV-Core/src/Utils/BaseDemo/js/BaseDemo.js
+++ b/UDV-Core/src/Utils/BaseDemo/js/BaseDemo.js
@@ -172,12 +172,10 @@ export class BaseDemo {
         this.moduleActivation[moduleId] = false;
 
         moduleClass.addEventListener(ModuleView.EVENT_ENABLED, () => {
-            console.log(`${moduleName} is enabled`);
             this.moduleActivation[moduleId] = true;
 
         });
         moduleClass.addEventListener(ModuleView.EVENT_DISABLED, () => {
-            console.log(`${moduleName} is disabled`);
             this.moduleActivation[moduleId] = false;
         });
 

--- a/UDV-Core/src/Utils/BaseDemo/js/BaseDemo.js
+++ b/UDV-Core/src/Utils/BaseDemo/js/BaseDemo.js
@@ -37,7 +37,10 @@ export class BaseDemo {
     get html() {
         return /*html*/`
             <header id="${this.headerId}">
-                <div id="${this.authFrameLocationId}"></div>
+                <div>
+                    <h1>UDV &bull;</h1>
+                    <div id="${this.authFrameLocationId}"></div>
+                </div>
                 <div id="_base_demo_struct_header_panel">
                     <img id="logoIMU" src="${this.imageFolder}/${this.logoIMUFile}" />
                     <img id="logoLIRIS" src="${this.imageFolder}/${this.logoLIRISFile}" />

--- a/UDV-Core/src/Utils/BaseDemo/js/BaseDemo.js
+++ b/UDV-Core/src/Utils/BaseDemo/js/BaseDemo.js
@@ -38,17 +38,19 @@ export class BaseDemo {
         return /*html*/`
             <header id="${this.headerId}">
                 <div id="${this.authFrameLocationId}"></div>
-                <img id="logoIMU" src="${this.imageFolder}/${this.logoIMUFile}" />
-                <img id="logoLIRIS" src="${this.imageFolder}/${this.logoLIRISFile}" />
-                <p style="display: inline-block; color: white;">
-                    Icons made by <a href="https://www.freepik.com/"
-                    title="Freepik">Freepik</a> from
-                    <a href="https://www.flaticon.com/"
-                    title="Flaticon">www.flaticon.com</a> is licensed by
-                    <a href="http://creativecommons.org/licenses/by/3.0/"
-                    title="Creative Commons BY 3.0" target="_blank">
-                    CC 3.0 BY</a>
-                </p>
+                <div id="_base_demo_struct_header_panel">
+                    <img id="logoIMU" src="${this.imageFolder}/${this.logoIMUFile}" />
+                    <img id="logoLIRIS" src="${this.imageFolder}/${this.logoLIRISFile}" />
+                    <p style="display: inline-block; color: white; margin: 0;">
+                        Icons made by <a href="https://www.freepik.com/"
+                        title="Freepik">Freepik</a> from
+                        <a href="https://www.flaticon.com/"
+                        title="Flaticon">www.flaticon.com</a><br> is licensed by
+                        <a href="http://creativecommons.org/licenses/by/3.0/"
+                        title="Creative Commons BY 3.0" target="_blank">
+                        CC 3.0 BY</a>
+                    </p>
+                </div>
             </header>
             <div id="_base_demo_stuct_main_panel">
                 <nav>

--- a/UDV-Core/src/Utils/BaseDemo/js/BaseDemo.js
+++ b/UDV-Core/src/Utils/BaseDemo/js/BaseDemo.js
@@ -62,8 +62,8 @@ export class BaseDemo {
                     class="choiceMenu">Temporal</label>
                 </div>
             </header>
-            <section id="contentSection">
-                <div id="viewerDiv"></div>
+            <section id="${this.contentSectionId}">
+                <div id="${this.viewerDivId}"></div>
             </section>
         `;
     }
@@ -231,7 +231,7 @@ export class BaseDemo {
         let moduleClass = this.getModuleById(moduleId);
 
         //dynamically color the button
-        moduleClass.parentElement = this.contentSectionElement;
+        moduleClass.parentElement = this.viewerDivElement;
         moduleClass.addEventListener(ModuleView.EVENT_ENABLED, () => {
             button.className = 'choiceMenu choiceMenuSelected';
 
@@ -253,7 +253,7 @@ export class BaseDemo {
         this.menuElement.insertBefore(frame,
             document.getElementById('openHamburger').nextSibling);
         const authView = this.getModuleById(authModuleId);
-        authView.parentElement = this.contentSectionElement;
+        authView.parentElement = this.viewerDivElement;
         const authService = authView.authenticationService;
         this.authenticationLoginButtonElement.onclick = () => {
             if (this.isModuleActive(authModuleId)) {
@@ -500,6 +500,14 @@ export class BaseDemo {
 
     get contentSectionElement() {
         return document.getElementById(this.contentSectionId);
+    }
+
+    get viewerDivId() {
+        return 'viewerDiv';
+    }
+
+    get viewerDivElement() {
+        return document.getElementById(this.viewerDivId);
     }
 
     get menuId() {

--- a/UDV-Core/src/Utils/Events/EventSender.js
+++ b/UDV-Core/src/Utils/Events/EventSender.js
@@ -7,11 +7,15 @@ export class EventSender {
     constructor() {
         /**
          * The listeners attached to a specific event.
+         * 
+         * @member
          */
         this.eventListeners = {};
         /**
          * The listeners attached to no particular event. They will receive
          * all notifications.
+         * 
+         * @member
          */
         this.allEventsListeners = [];
     }
@@ -27,10 +31,11 @@ export class EventSender {
     }
 
     /**
-     * Registers an event listener attached to a specific event. The `action` function will
-     * be called only when `event` is fired.
+     * Registers an event listener attached to a specific event. The `action`
+     * function will be called only when `event` is fired.
+     * 
      * @param event The event to listen to.
-     * @param action The function to call. Can take an argument (`data`).
+     * @param {(data: any)} action The function to call.
      */
     addEventListener(event, action) {
         if (this.eventListeners[event]) {
@@ -41,9 +46,10 @@ export class EventSender {
     }
 
     /**
-     * Registers an event listener attached to no specific event. The `action` function will
-     * be called when any event is fired.
-     * @param action The function to call. Can take an argument (`data`).
+     * Registers an event listener attached to no specific event. The `action`
+     * function will be called when any event is fired.
+     * 
+     * @param {(event: any, data: any)} action The function to call.
      */
     addListener(action) {
         if (typeof(action) !== 'function') {
@@ -55,6 +61,7 @@ export class EventSender {
     /**
      * Sends an event to the listeners. `event` must be first registers through the `registerEvent`
      * method. An argument can be passed but is optional.
+     * 
      * @param event The event to fire. Must be first registered. 
      * @param data The optional data to pass as parameter.
      */

--- a/UDV-Core/src/Utils/GUI/css/window.css
+++ b/UDV-Core/src/Utils/GUI/css/window.css
@@ -8,10 +8,9 @@
     padding: 0;
     resize: both;
     overflow: hidden;
-    border-radius: 4px;
     display: grid;
     grid-template-rows: 30px auto;
-    box-shadow: 0px 0px 10px 0px rgba(0,0,0,0.75);
+    box-shadow: 0px 0px 2px 0px rgba(0,0,0,0.75);
 }
 
 .window-header {
@@ -36,6 +35,16 @@
     height: 26px;
     right: 2px;
     top: 2px;
+    background-color: transparent;
+    color: white;
+    border: none;
+    font-size: 20px;
+    font-weight: bold;
+    transition: background-color 0.2s ease;
+}
+
+.window-close-button:hover {
+    background-color: #f95a5a;
 }
 
 .window-content {

--- a/UDV-Core/src/Utils/GUI/css/window.css
+++ b/UDV-Core/src/Utils/GUI/css/window.css
@@ -20,7 +20,7 @@
     padding: 5px;
     overflow-x: hidden;
     overflow-y: unset;
-    cursor: pointer;
+    cursor: default;
 }
 
 .window-header .window-title {
@@ -45,6 +45,7 @@
 
 .window-close-button:hover {
     background-color: #f95a5a;
+    cursor: default;
 }
 
 .window-content {

--- a/UDV-Core/src/Utils/GUI/js/Draggable.js
+++ b/UDV-Core/src/Utils/GUI/js/Draggable.js
@@ -25,8 +25,16 @@ export function dragElement(elmnt, dragelmnt) {
         pos3 = e.clientX;
         pos4 = e.clientY;
         // set the element's new position:
-        elmnt.style.top = (elmnt.offsetTop - pos2) + "px";
-        elmnt.style.left = (elmnt.offsetLeft - pos1) + "px";
+        let newTop = (elmnt.offsetTop - pos2);
+        if (newTop < 0) {
+            newTop = 0;
+        }
+        let newLeft = (elmnt.offsetLeft - pos1);
+        if (newLeft < 0) {
+            newLeft = 0;
+        }
+        elmnt.style.top = newTop + "px";
+        elmnt.style.left = newLeft + "px";
     }
 
     function closeDragElement() {

--- a/UDV-Core/src/Utils/GUI/js/Draggable.js
+++ b/UDV-Core/src/Utils/GUI/js/Draggable.js
@@ -7,7 +7,6 @@ export function dragElement(elmnt, dragelmnt) {
 
     function dragMouseDown(e) {
         e = e || window.event;
-        e.preventDefault();
         // get the mouse cursor position at startup:
         pos3 = e.clientX;
         pos4 = e.clientY;

--- a/UDV-Core/src/Utils/GUI/js/Window.js
+++ b/UDV-Core/src/Utils/GUI/js/Window.js
@@ -148,7 +148,7 @@ export class Window extends ModuleView {
         return `
             <div class="window-header" id="${this.headerId}">
                 <h1 class="window-title" id="${this.headerTitleId}">${this.title}</h1>
-                <button class="window-close-button" id="${this.headerCloseButtonId}">CLOSE</button>
+                <button class="window-close-button" id="${this.headerCloseButtonId}">&#10799;</button>
             </div>
             <div class="window-content" id="${this.contentId}">
                 <div class="window-inner-content" id="${this.innerContentId}">

--- a/UDV-Core/src/Utils/GUI/js/Window.js
+++ b/UDV-Core/src/Utils/GUI/js/Window.js
@@ -1,5 +1,6 @@
 import { dragElement } from './Draggable.js';
 import { ModuleView } from '../../ModuleView/ModuleView.js';
+import { windowManager } from "./WindowManager";
 
 // Documentation is on the Wiki
 // URL : https://github.com/MEPP-team/UDV/wiki/Window-Framework
@@ -47,6 +48,8 @@ export class Window extends ModuleView {
         this.registerEvent(Window.EVENT_DESTROYED);
         this.registerEvent(Window.EVENT_SHOWN);
         this.registerEvent(Window.EVENT_HIDDEN);
+
+        windowManager.registerWindow(this);
     }
 
     //////////// Methods to override

--- a/UDV-Core/src/Utils/GUI/js/Window.js
+++ b/UDV-Core/src/Utils/GUI/js/Window.js
@@ -1,6 +1,6 @@
 import { dragElement } from './Draggable.js';
 import { ModuleView } from '../../ModuleView/ModuleView.js';
-import { windowManager } from "./WindowManager";
+import { windowManager } from "./WindowManager.js";
 
 // Documentation is on the Wiki
 // URL : https://github.com/MEPP-team/UDV/wiki/Window-Framework

--- a/UDV-Core/src/Utils/GUI/js/WindowManager.js
+++ b/UDV-Core/src/Utils/GUI/js/WindowManager.js
@@ -40,7 +40,6 @@ class WindowManager {
     });
     window.addEventListener(Window.EVENT_DESTROYED, () => {
       delete this.createdWindows[window.name];
-      console.log(this.createdWindows);
       if (Object.keys(this.createdWindows).length === 0) {
         this.highestZIndex = BASE_Z_INDEX;
       }

--- a/UDV-Core/src/Utils/GUI/js/WindowManager.js
+++ b/UDV-Core/src/Utils/GUI/js/WindowManager.js
@@ -1,0 +1,56 @@
+import { Window } from "./Window";
+
+const BASE_Z_INDEX = 100;
+
+/**
+ * Class used to manage windows. Every window is registered into the manager
+ * 
+ */
+class WindowManager {
+  constructor() {
+    /**
+     * List of all registered windows.
+     * 
+     * @member {Window[]} windows
+     */
+    this.windows = [];
+
+    this.createdWindows = {};
+
+    this.highestZIndex = BASE_Z_INDEX;
+    console.log('Window manager initialized');
+  }
+
+  /**
+   * Registers a window.
+   * 
+   * @param {Window} window 
+   */
+  registerWindow(window) {
+    this.windows.push(window);
+    window.addEventListener(Window.EVENT_CREATED, () => {
+      this.createdWindows[window.name] = true;
+      window.window.style.zIndex = this.newTopIndex();
+      window.window.addEventListener('mousedown', () => {
+        if (window.isCreated
+            && window.window.style.zIndex < this.highestZIndex) {
+          window.window.style.zIndex = this.newTopIndex();
+        }
+      });
+    });
+    window.addEventListener(Window.EVENT_DESTROYED, () => {
+      delete this.createdWindows[window.name];
+      console.log(this.createdWindows);
+      if (Object.keys(this.createdWindows).length === 0) {
+        this.highestZIndex = BASE_Z_INDEX;
+      }
+    });
+  }
+
+  newTopIndex() {
+    this.highestZIndex += 1;
+    return this.highestZIndex;
+  }
+}
+
+export let windowManager = new WindowManager();

--- a/UDV-Core/src/Utils/GUI/js/WindowManager.js
+++ b/UDV-Core/src/Utils/GUI/js/WindowManager.js
@@ -1,4 +1,4 @@
-import { Window } from "./Window";
+import { Window } from "./Window.js";
 
 const BASE_Z_INDEX = 100;
 

--- a/UDV-Core/src/Utils/GUI/js/WindowManager.js
+++ b/UDV-Core/src/Utils/GUI/js/WindowManager.js
@@ -18,7 +18,6 @@ class WindowManager {
     this.createdWindows = {};
 
     this.highestZIndex = BASE_Z_INDEX;
-    console.log('Window manager initialized');
   }
 
   /**

--- a/UDV-Core/src/Utils/ModuleView/ModuleView.js
+++ b/UDV-Core/src/Utils/ModuleView/ModuleView.js
@@ -5,17 +5,22 @@ import { EventSender } from '../Events/EventSender.js';
  * a module, but is strongly advised as it simplifies the integration is demos.
  */
 export class ModuleView extends EventSender {
+    /**
+     * Creates a new ModuleView.
+     */
     constructor() {
         super();
-
-        this.registerEvent(ModuleView.EVENT_ENABLED);
-        this.registerEvent(ModuleView.EVENT_DISABLED);
 
         /**
          * Represents the parent HTML element of this view. Must be defined
          * by the user of the view
+         * 
+         * @member {HTMLElement}
          */
-        this.parentElement;
+        this.parentElement = null;
+
+        this.registerEvent(ModuleView.EVENT_ENABLED);
+        this.registerEvent(ModuleView.EVENT_DISABLED);
     }
 
     ///////// Overideable methods
@@ -27,31 +32,39 @@ export class ModuleView extends EventSender {
     // send appropriate events.
     /**
      * Must be overriden by the implementing class. Supposedly enables the view.
+     * @abstract
      */
-    enableView() { }
+    async enableView() { }
     /**
      * Must be overriden by the implementing class. Supposedly disables the view.
+     * @abstract
      */
-    disableView() { }
+    async disableView() { }
 
     ///////// Do not override
     // These methods are the public methods called to destroy or
     // create the view.
     /**
-     * Enables the view (depends on the implementation)
-     * Sends a EVENT_ENABLED event
+     * Enables the view (depends on the implementation).
+     * 
+     * Sends a EVENT_ENABLED event once the view is enabled.
+     * 
+     * @async
      */
-    enable() {
-        this.enableView();
+    async enable() {
+        await this.enableView();
         this.sendEvent(ModuleView.EVENT_ENABLED);
     }
 
     /**
-     * Disables the view (depends on the implementation)
-     * Sends a EVENT_DISABLED event
+     * Disables the view (depends on the implementation).
+     * 
+     * Sends a EVENT_DISABLED event once the view is disabled.
+     * 
+     * @async
      */
-    disable() {
-        this.disableView();
+    async disable() {
+        await this.disableView();
         this.sendEvent(ModuleView.EVENT_DISABLED);
     }
 
@@ -61,13 +74,13 @@ export class ModuleView extends EventSender {
      * Event sent when the view is enabled
      */
     static get EVENT_ENABLED() {
-        return 'ENABLED';
+        return 'MODULE_VIEW_ENABLED';
     }
 
     /**
      * Event sent when the view is disabled
      */
     static get EVENT_DISABLED() {
-        return 'DISABLED';
+        return 'MODULE_VIEW_DISABLED';
     }
 }

--- a/UDV-Core/src/Utils/Request/RequestService.js
+++ b/UDV-Core/src/Utils/Request/RequestService.js
@@ -8,6 +8,9 @@ export function RequestService() {
 
     };
 
+    /**
+     * @deprecated Prefer using `RequestService.request` instead.
+     */
     this.send = function (method, url, body = '', authenticate = true) {
         return this.request(method, url, {
             body: body,
@@ -15,6 +18,20 @@ export function RequestService() {
         });
     };
 
+    /**
+     * Performs an HTTP request.
+     * 
+     * @async
+     * @param {string} method The HTTP method. Accepted methods include `GET`,
+     * `DELETE`, `POST` and `PUT`.
+     * @param {string} url The requested URL.
+     * @param {object} options A dictionnary of optional parameters. These
+     * options include  
+     * - `body` : the request body
+     * - `authenticate` : set to false if you don't want the request to use
+     * authentication
+     * - `responseType` : the expected response type
+     */
     this.request = (method, url, options = {}) => {
         let args = options || {};
         let body = args.body || '';
@@ -29,7 +46,7 @@ export function RequestService() {
             if (this.useAuthentication && authenticate) {
                 const token = window.sessionStorage.getItem('user.token');
                 if (token === null) {
-                    reject('Login needed for this request');
+                    reject(new AuthNeededError());
                     return;
                 }
                 req.setRequestHeader('Authorization', `Bearer ${token}`);
@@ -61,4 +78,11 @@ export function RequestService() {
     };
 
     this.initialize();
+}
+
+export class AuthNeededError extends Error {
+    constructor() {
+        super('Login needed for this request');
+        this.name = 'AuthNeededError';
+    }
 }

--- a/UDV-Core/src/Utils/Request/RequestService.js
+++ b/UDV-Core/src/Utils/Request/RequestService.js
@@ -5,7 +5,7 @@ export function RequestService() {
     this.useAuthentication = false;
 
     this.initialize = function () {
-        console.log('Request service initialized');
+
     };
 
     this.send = function (method, url, body = '', authenticate = true) {


### PR DESCRIPTION
This PR focuses on visual enhancements of the app to fix issues and improve ergonomy.

## Changes

- Most major modules now use Window as their view (consultdoc, contribute, guided tours)
- Base demo now includes geocoding
- Changed the appearance of Base Demo to get rid of the wide left menu (now it is a fixed-size menu with icons, names are displayed on hover). The html is also cleaner (the "content view" node has the same size as we see it, got rid of unused CSS).
- Windows default location has been updated to correspond to the [interface concept](https://github.com/MEPP-team/RICT/blob/master/Doc/Devel/Design/Interface%20Design.md#web-demo-interface)

## Issues fixed

- #68, #71, #76 -> fixed by using Window for the view of main modules, changing their default position and updating the base demo interface (for #76, still have to manage the case where no guided tour is found)
- #70 : image src was incorrect
- #75 added popups
- #77 fixed opacity
- #78 updated index.html

## Screenshot : new interface

![Screenshot_20190614_112718](https://user-images.githubusercontent.com/7014405/59500272-665ca980-8e99-11e9-9496-e952fe7b50e7.png)
