### PR TITLE
Feature/groups

### DIFF
--- a/UDV-Core/install.sh
+++ b/UDV-Core/install.sh
@@ -1,0 +1,23 @@
+## This script only works when invocated where it stands...
+cd "$(dirname "$0")" || exit
+
+mkdir dist
+pushd dist
+git clone https://github.com/Crejak/itowns.git
+pushd itowns
+git checkout fix/material
+npm install
+# The following command was automatically launched by 'npm install' as the
+# 'prepublish' script. However, Itowns moved this command  to the 
+# 'prepublishOnly' script which is only launched before 'npm publish'. 
+# More infos: https://docs.npmjs.com/misc/scripts
+npm run build && npm run transpile 
+npm pack
+popd
+popd
+# Installs the tarball produced by `npm pack`.
+npm install dist/itowns/itowns-2.12.0.tgz
+npm install
+### The following is only needed in server mode (since in devel mode
+# npm start already takes care of that stage).
+npm run build

--- a/UDV-Core/install.sh
+++ b/UDV-Core/install.sh
@@ -3,9 +3,8 @@ cd "$(dirname "$0")" || exit
 
 mkdir dist
 pushd dist
-git clone https://github.com/Crejak/itowns.git
+git clone https://github.com/iTowns/itowns.git
 pushd itowns
-git checkout fix/material
 npm install
 # The following command was automatically launched by 'npm install' as the
 # 'prepublish' script. However, Itowns moved this command  to the 

--- a/UDV-Core/package.json
+++ b/UDV-Core/package.json
@@ -32,7 +32,7 @@
     "bootstrap": "^4.1.1",
     "es6-promise": "^4.0.5",
     "handlebars": "^4.0.11",
-    "itowns": "^2.12.0",
+    "itowns": "file:dist/itowns/itowns-2.12.0.tgz",
     "jquery": "^3.3.1",
     "moment": "^2.19.0",
     "popper.js": "^1.14.3",

--- a/UDV-Core/src/Extensions/3DTilesDebug/views/3DTilesDebugWindow.js
+++ b/UDV-Core/src/Extensions/3DTilesDebug/views/3DTilesDebugWindow.js
@@ -206,10 +206,12 @@ export class Debug3DTilesWindow extends Window {
     try {
       let tileId = Number.parseInt(this.groupColorTileInputElement.value);
       let batchIds = JSON.parse('[' + this.groupColorBatchInputElement.value + ']');
-      let color = new THREE.Color(this.groupColorColorInputElement.value);
+      let color = new THREE.Color(this.groupColorColorInputElement.value)
       let opacity = Number.parseFloat(this.groupColorOpacityInputElement.value);
-      createTileGroupsFromBatchIDs(getTileInLayer(this.layer, tileId), color,
-        opacity, batchIds);
+      createTileGroupsFromBatchIDs(getTileInLayer(this.layer, tileId), [{
+          material: {color, opacity},
+          batchIDs: batchIds
+      }]);
       updateITownsView(this.itownsView, this.layer);
     } catch (e) {
       alert(e);

--- a/UDV-Core/src/Extensions/3DTilesDebug/views/3DTilesDebugWindow.js
+++ b/UDV-Core/src/Extensions/3DTilesDebug/views/3DTilesDebugWindow.js
@@ -206,7 +206,7 @@ export class Debug3DTilesWindow extends Window {
     try {
       let tileId = Number.parseInt(this.groupColorTileInputElement.value);
       let batchIds = JSON.parse('[' + this.groupColorBatchInputElement.value + ']');
-      let color = new THREE.Color(this.groupColorColorInputElement.value)
+      let color = new THREE.Color(this.groupColorColorInputElement.value);
       let opacity = Number.parseFloat(this.groupColorOpacityInputElement.value);
       createTileGroupsFromBatchIDs(getTileInLayer(this.layer, tileId), [{
           material: {color, opacity},

--- a/UDV-Core/src/Extensions/3DTilesDebug/views/3DTilesDebugWindow.js
+++ b/UDV-Core/src/Extensions/3DTilesDebug/views/3DTilesDebugWindow.js
@@ -58,17 +58,17 @@ export class Debug3DTilesWindow extends Window {
       <h3>Color groups</h3>
       <div>
         <form id="${this.groupColorFormId}">
-          <label for="${this.groupColorTileInputId}">Tile ID</label>
-          <input id="${this.groupColorTileInputId}" type="text">
+          <label for="${this.groupColorTileInputId}">Tile ID</label><br>
+          <input id="${this.groupColorTileInputId}" type="text"><br>
           <label for="${this.groupColorBatchInputId}">Batch IDs
-            (separated by comas)</label>
-          <input id="${this.groupColorBatchInputId}" type="text">
-          <label for="${this.groupColorColorInputId}">Color</label>
-          <input id="${this.groupColorColorInputId}" type="color">
+            (separated by comas)</label><br>
+          <input id="${this.groupColorBatchInputId}" type="text"><br>
+          <label for="${this.groupColorColorInputId}">Color</label><br>
+          <input id="${this.groupColorColorInputId}" type="color"><br>
           <label for="${this.groupColorOpacityInputId}">Opacity :
-            <span id="${this.groupColorOpacitySpanId}">1</span></label>
+            <span id="${this.groupColorOpacitySpanId}">1</span></label><br>
           <input type="range" min="0" max="1" value="1" step="0.01"
-            id="${this.groupColorOpacityInputId}">
+            id="${this.groupColorOpacityInputId}"><br>
           <input type="submit" value="Color">
         </form>
       </div>

--- a/UDV-Core/src/Extensions/Contribute/src/Contribute.css
+++ b/UDV-Core/src/Extensions/Contribute/src/Contribute.css
@@ -16,6 +16,11 @@
   font-size: 14;
 }
 
+#creationForm input, #creationForm select {
+  box-sizing: border-box;
+  width: 100%;
+}
+
 #closeCreation{
   position: absolute;
   z-index: 40;

--- a/UDV-Core/src/Extensions/DocToValidate/views/DocToValidateStyle.css
+++ b/UDV-Core/src/Extensions/DocToValidate/views/DocToValidateStyle.css
@@ -1,30 +1,3 @@
-.docToValidate_Window {
-    position: absolute;
-    width: 380px;
-    max-height: 90%;
-    left: 300px;
-    background-color: rgba(30,30,30,0.6);
-    border : 1px solid rgb(90,90,90);
-    color: white;
-    resize: both;
-    overflow: auto;
-}
-
-.docToValidate_Window .innerWindow {
-    padding: 5px;
-}
-
-.docToValidate_Window_header {
-    position: relative;
-    background-color: rgba(0, 0, 0, 0.6);
-    padding-left: 10px;
-}
-
-.docToValidate_Window_header h2 {
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
 .docToValidate_buttonClose {
     position: absolute;
     top: 0;
@@ -33,7 +6,8 @@
     height: 80%;
 }
 
-.window-inner-content input, .window-inner-content select {
+#docToValidate_udpateForm input, #docToValidate_updateForm select,
+#docToValidate_searchForm input, #docToValidate_searchForm select {
     box-sizing: border-box;
     width: 100%;
 }

--- a/UDV-Core/src/Utils/3DTiles/3DTilesBuildingUtils.js
+++ b/UDV-Core/src/Utils/3DTiles/3DTilesBuildingUtils.js
@@ -81,6 +81,7 @@ export function getTilesBuildingInfo(layer, tbi = null) {
           tbi.buildings[buildingId] = {};
           tbi.buildings[buildingId].arrayIndexes = [];
           tbi.buildings[buildingId].tileId = tile.tileId;
+          tbi.buildings[buildingId].batchId = batchId;
           tbi.buildings[buildingId].centroid = null;
 
           newBuildingIds.push(buildingId);

--- a/UDV-Core/src/Utils/3DTiles/3DTilesUtils.js
+++ b/UDV-Core/src/Utils/3DTiles/3DTilesUtils.js
@@ -60,12 +60,13 @@ export function getVisibleTiles(layer) {
       // It's an actual tile
       tiles.push(node);
     };
-    node.children.forEach((child) => {
+    for (let childIndex = 0; childIndex < node.children.length; childIndex++) {
+      let child = node.children[childIndex];
       if (child.type === 'Object3D') {
         //This child can be a tile or contain tiles so we explore it too
         exploreTree(child);
       }
-    });
+    }
   };
   exploreTree(rootTile);
   return tiles;
@@ -195,7 +196,8 @@ export function createTileGroups(tile, materials, ranges) {
   let materialIndexTable = {};
 
   // Create the materials
-  for (let [materialIndex, material] of materials.entries()) {
+  for (let materialIndex = 0; materialIndex < materials.length; materialIndex++) {
+    let material = materials[materialIndex];
     if (material.transparent === undefined) {
       material.transparent = true;
     }
@@ -217,7 +219,8 @@ export function createTileGroups(tile, materials, ranges) {
     
     // Merge consecutive ranges with the same material
     let mergedRanges = [];
-    for (let [index, range] of ranges.entries()) {
+    for (let index = 0; index < ranges.length; index++) {
+      let range = ranges[index];
       if (index === 0) {
         mergedRanges.push(range);
       } else {
@@ -233,7 +236,8 @@ export function createTileGroups(tile, materials, ranges) {
     ranges = mergedRanges;
 
     // Add the new groups
-    for (let range of ranges) {
+    for (let rangeIndex = 0; rangeIndex < ranges.length; rangeIndex++) {
+      let range = ranges[rangeIndex];
       mesh.geometry.addGroup(range.start, range.count, materialIndexTable[range.material]);
     }
 
@@ -290,16 +294,19 @@ export function createTileGroupsFromBatchIDs(tile, groups) {
   // to associate batchIDs with their material
   let batchIDs = [];
   let materialIndexTable = {};
-  for (let group of groups) {
+  for (let groupIndex = 0; groupIndex < groups.length; groupIndex++) {
+    let group = groups[groupIndex];
+
     // Push the material
     let materialIndex = materials.length;
     materials.push(group.material)
 
     // Push the batch IDs and remember their material
-    group.batchIDs.forEach((batchID) => {
+    for (let batchIDIndex = 0; batchIDIndex < group.batchIDs.length; batchIDIndex++) {
+      let batchID = group.batchIDs[batchIDIndex];
       batchIDs.push(batchID);
       materialIndexTable[batchID] = materialIndex;
-    });
+    }
   }
 
   // Sort the batch IDs
@@ -315,7 +322,7 @@ export function createTileGroupsFromBatchIDs(tile, groups) {
   };
 
   // Loop once over all vertices to find the ranges
-  for (let index = 0; index < mesh.geometry.attributes._BATCHID.count; index++) {
+  for (let index = 0, total = mesh.geometry.attributes._BATCHID.count; index < total; index++) {
     let batchID = mesh.geometry.attributes._BATCHID.array[index];
 
     // If we found a batch ID that is greater than the one we're searching, it

--- a/UDV-Core/src/Utils/3DTiles/3DTilesUtils.js
+++ b/UDV-Core/src/Utils/3DTiles/3DTilesUtils.js
@@ -179,7 +179,7 @@ export function setTileVerticesColor(tile, newColor, indexArray = null) {
  * vertex of the range and count is the number of vertices in the range.
  */
 export function createTileGroups(tile, groupColor = 0xff00ff, groupOpacity = 1, ranges = []) {
-  let mesh = getMesh(tile);
+  let mesh = getMeshFromTile(tile);
 
   if (!Array.isArray(mesh.material)) {
     //need to create the array
@@ -238,7 +238,7 @@ export function createTileGroups(tile, groupColor = 0xff00ff, groupOpacity = 1, 
 export function createTileGroupsFromBatchIDs(tile, groupColor, groupOpacity, batchIDs) {
   let ranges = [];
 
-  let mesh = getMesh(tile);
+  let mesh = getMeshFromTile(tile);
 
   batchIDs.sort((a, b) => {
     return a - b;
@@ -360,7 +360,7 @@ export function getVerticesCentroid(tile, indexArray) {
   return vertexCentroid;
 }
 
-function getMesh(tile) {
+export function getMeshFromTile(tile) {
   if (!tile) {
     throw 'Tile not loaded in view';
   }
@@ -376,6 +376,23 @@ function getMesh(tile) {
 
   if (tile.geometry.type !== 'BufferGeometry') {
     throw 'Tile has no buffer geometry';
+  }
+
+  return tile;
+}
+
+export function getObject3DFromTile(tile) {
+  if (!tile) {
+    throw 'Tile not loaded in view';
+  }
+
+  //Find the 'Object3D' part of the tile
+  while (!!tile.parent && !(tile.type === 'Object3D')) {
+    tile = tile.parent;
+  }
+
+  if (!tile.batchTable) {
+    throw 'Invalid tile : no batch table';
   }
 
   return tile;

--- a/UDV-Core/src/Utils/3DTiles/3DTilesUtils.js
+++ b/UDV-Core/src/Utils/3DTiles/3DTilesUtils.js
@@ -232,11 +232,12 @@ export function createTileGroups(tile, materials, ranges) {
     }
     ranges = mergedRanges;
 
-    // Adding groups for the new material
+    // Add the new groups
     for (let range of ranges) {
       mesh.geometry.addGroup(range.start, range.count, materialIndexTable[range.material]);
     }
 
+    // Fill the "blanks" between the ranges with the default material
     if (ranges[0].start > 0) {
       mesh.geometry.addGroup(0, ranges[0].start, 0);
     }

--- a/UDV-Core/src/Utils/3DTiles/3DTilesUtils.js
+++ b/UDV-Core/src/Utils/3DTiles/3DTilesUtils.js
@@ -172,7 +172,7 @@ export function setTileVerticesColor(tile, newColor, indexArray = null) {
  * Creates tile groups and associate them with the given materials.
  * 
  * @param {*} tile The 3DTiles tile.
- * @param {Array<any>} materialProps An array of material parameters. Each entry
+ * @param {Array<any>} materialsProps An array of material parameters. Each entry
  * should be an object that will be passed as parameter in the THREE.Material
  * constructor. Accepted values are for example `color` or `opacity`; actually
  * any property of the `MeshLambertMaterial` class is valid (see [THREE.js
@@ -199,7 +199,7 @@ export function setTileVerticesColor(tile, newColor, indexArray = null) {
  * ];
  * createTileGroups(tile, materialProps, ranges);
  */
-export function createTileGroups(tile, materialProps, ranges) {
+export function createTileGroups(tile, materialsProps, ranges) {
   let mesh = getMeshFromTile(tile);
 
   let defaultMaterial = Array.isArray(mesh.material) ?
@@ -213,13 +213,13 @@ export function createTileGroups(tile, materialProps, ranges) {
   let materialIndexTable = {};
 
   // Create the materials
-  for (let materialIndex = 0; materialIndex < materialProps.length; materialIndex++) {
-    let material = materialProps[materialIndex];
-    if (material.transparent === undefined) {
-      material.transparent = true;
+  for (let materialIndex = 0; materialIndex < materialsProps.length; materialIndex++) {
+    let props = materialsProps[materialIndex];
+    if (props.transparent === undefined) {
+      props.transparent = true;
     }
     materialIndexTable[materialIndex] = mesh.material.length;
-    mesh.material.push(new THREE.MeshLambertMaterial(material));
+    mesh.material.push(new THREE.MeshLambertMaterial(props));
   }
 
   // Clear the existing groups

--- a/UDV-Core/src/Utils/3DTiles/3DTilesUtils.js
+++ b/UDV-Core/src/Utils/3DTiles/3DTilesUtils.js
@@ -172,17 +172,34 @@ export function setTileVerticesColor(tile, newColor, indexArray = null) {
  * Creates tile groups and associate them with the given materials.
  * 
  * @param {*} tile The 3DTiles tile.
- * @param {Array<any>} materials An array of material parameters. Each entry
+ * @param {Array<any>} materialProps An array of material parameters. Each entry
  * should be an object that will be passed as parameter in the THREE.Material
- * constructor. Accepted values are for example `color` or `opacity` (see
- * THREE.js documentation).
+ * constructor. Accepted values are for example `color` or `opacity`; actually
+ * any property of the `MeshLambertMaterial` class is valid (see [THREE.js
+ * documentation](https://threejs.org/docs/#api/en/materials/MeshLambertMaterial)).
  * @param {Array<any>} ranges An array of ranges. A range is an object with 3
  * propeties :
  * - `start`: the start index of the group of vertices
  * - `count`: the number of vertices of the group
  * - `material`: the index of the material in the materials array
+ * 
+ * @example
+ * // Fetch the tile
+ * let tile = getTileInLayer(this.layer, 6);
+ * // Define 2 materials : #0 is red and a bit transparent, #1 is invisible
+ * let materialProps = [
+ *   { color: 0xff0000, opacity: 0.8},
+ *   { opacity: 0}
+ * ];
+ * // Define 3 ranges associated with the materials
+ * let ranges = [
+ *   { start: 34629, count: 102, material: 1 },
+ *   { start: 34131, count: 174, material: 0 },
+ *   { start: 34731, count: 462, material: 0 }
+ * ];
+ * createTileGroups(tile, materialProps, ranges);
  */
-export function createTileGroups(tile, materials, ranges) {
+export function createTileGroups(tile, materialProps, ranges) {
   let mesh = getMeshFromTile(tile);
 
   let defaultMaterial = Array.isArray(mesh.material) ?
@@ -192,12 +209,12 @@ export function createTileGroups(tile, materials, ranges) {
   // Reset the materials
   mesh.material = [ defaultMaterial ];
 
-  // Material index table (index in materials -> index in mesh.material)
+  // Material index table (index in materialProps -> index in mesh.material)
   let materialIndexTable = {};
 
   // Create the materials
-  for (let materialIndex = 0; materialIndex < materials.length; materialIndex++) {
-    let material = materials[materialIndex];
+  for (let materialIndex = 0; materialIndex < materialProps.length; materialIndex++) {
+    let material = materialProps[materialIndex];
     if (material.transparent === undefined) {
       material.transparent = true;
     }
@@ -272,10 +289,13 @@ export function createTileGroups(tile, materials, ranges) {
  * - `batchIDs` contains the batch IDs to be applied the given material.
  * 
  * @example
+ * // Fetch the tile
  * let tile = getTileInLayer(layer, 6);
+ * // Create groups for two types of objects : the first type has a red,
+ * // transparent material. The second one is invisible.
  * createTileGroupsFromBatchIDs(tile, [
  *   {
- *     material: {color: 0xff0000},
+ *     material: {color: 0xff0000, opacity: 0.8},
  *     batchIDs: [64, 67]
  *   },
  *   {

--- a/UDV-Core/src/Utils/3DTiles/3DTilesUtils.md
+++ b/UDV-Core/src/Utils/3DTiles/3DTilesUtils.md
@@ -125,6 +125,15 @@ This function is relatively straightforward. It simply counts the number of tile
 This function is used to set the color of the vertices of a tile. It does not affect the material color, but rather the geometry 'color' attribute. The default color rendering method is also changed (the `vertexColors` property of the material is set to `THREE.VertexColors`).  
 It is possible to change the color of specific vertices of the tile. They are specified in the optional `indexArray` parameter, which is an array of indexes for the vertices (same indexes used in the `_BATCHID` attribute, for example).
 
+### `createTileGroups(tile, materials, ranges)` - Create tile groups and set materials
+
+This function is used to group the vertices of the tile into different "groups". A group is a set of consecutive vertices with the same material. This function can be used to change the material (color, opacity, etc.) of different parts of the tile.  
+Different materials can be used at the same time.
+
+### `createTileGroupsFromBatchIDs(tile, groups)` - Create tile groups from batch IDs
+
+This function serves as a convenient helper to create tile groups without specifying vertex ranges, but rather batch IDs. Batch IDs are much simpler to manipulate and retrieve, with for example the `pickObjectsAt` function.
+
 ### `removeTileVerticesColor(tile)` - Remove the color from tile vertices
 
 This function removes the `color` attribute from the geometry of the tile and sets the `vertexColors` property of the material to `THREE.NoColor`, meaning that the tile color will be determined by only the material color.
@@ -136,6 +145,14 @@ The purpose of this function is to tell the iTowns view to update the scene. It 
 ### `getVerticesCentroid(tile, indexArray)` - Computes the centroid of the vertices
 
 This function computes the centroid of the given vertices. `indexArray` is the array of indexes used to specify which vertices in the tile should be considered. This array is assumed to be contiguous and sorted.
+
+### `getMeshFromTile(tile)` - Gets the mesh component of a tile
+
+Search for the last child of a tile in its hierarchy, which should be an object of type "Mesh". It should have a geometry.
+
+### `getObject3DFromTile(tile)` - Gets the root component of a tile
+
+Search for the root component of a tile in its hierarchy, which should be an object of type "Object3D". It should have a batch table.
 
 ## 3DTilesBuildingUtils
 
@@ -217,3 +234,20 @@ if (!!buildingInfo) {
 If we had previously colored another building, we want to un-color it. We do that by removing vertex colors from the tile.
 
 We have to call the function `updateITownsView` in order to the view to be redrawn. Otherwise, the color changes won't appear in the scene.
+
+### Create tile groups to apply materials
+
+Let's say we want to apply different styles to different parts of a tile (like buildings). Some buildings will be drawn in red, and other will be hidden. We can do that by defining tile groups :
+
+```js
+let tile = getTileInLayer(this.layer, 6);
+createTileGroupsFromBatchIDs(tile, [{
+  material: {color: 0xff0000},
+  batchIDs: [64, 66]
+}, {
+  material: {opacity: 0},
+  batchIDs: [65, 67]
+}]);
+```
+
+In this example, the city objects 64 and 66 from the tile 6 will be drawn in red, whereas the city objects 65 and 67 will be invisible.


### PR DESCRIPTION
- Added helper functions to work with groups in 3DTiles tiles.
  - `createTileGroups` creates new tile groups from the given materials and vertex ranges.
  - `createTileGroupsFromBatchIDs` does the same with materials and batch IDs (instead of vertex ranges).
- Along with that, a new form has been added to 3DTilesDebug to show the possibility of the new functions. 
- Weird CSS rules in DocToValidateStyle have been removed / updated