### PR TITLE
Merge materials that have the same properties

### DIFF
--- a/UDV-Core/src/Utils/3DTiles/3DTilesUtils.js
+++ b/UDV-Core/src/Utils/3DTiles/3DTilesUtils.js
@@ -1,4 +1,5 @@
 import * as THREE from '../../../node_modules/three/build/three.js';
+import { objectEquals } from '../DataProcessing/DataProcessing.js';
 
 /**
  * Search a batch table in a tile. A tile is a THREE.js 3DObject with a 
@@ -317,9 +318,15 @@ export function createTileGroupsFromBatchIDs(tile, groups) {
   for (let groupIndex = 0; groupIndex < groups.length; groupIndex++) {
     let group = groups[groupIndex];
 
-    // Push the material
-    let materialIndex = materials.length;
-    materials.push(group.material)
+    // Check if a similar material has been added
+    let materialIndex = materials.findIndex((mat) => {
+      return objectEquals(mat, group.material);
+    });
+    if (materialIndex < 0) {
+      // If the material is new, push it
+      materialIndex = materials.length;
+      materials.push(group.material)
+    }
 
     // Push the batch IDs and remember their material
     for (let batchIDIndex = 0; batchIDIndex < group.batchIDs.length; batchIDIndex++) {

--- a/UDV-Core/src/Utils/DataProcessing/DataProcessing.js
+++ b/UDV-Core/src/Utils/DataProcessing/DataProcessing.js
@@ -79,3 +79,28 @@ export function getAttributeByPath(obj, path) {
   }
   return val;
 }
+
+/**
+ * Checks the equality of two objects by their properties. For two objects to
+ * be equal, they must have the same keys and the same values.
+ * 
+ * @param {any} a An object.
+ * @param {any} b An object.
+ */
+export function objectEquals(a, b) {
+  // Set of a's keys
+  let keys = new Set(Object.keys(a));
+  for (let key of Object.keys(b)) {
+  	if (!keys.has(key)) {
+      // If b has a key unknown to a, they aren't equal
+    	return false;
+    }
+  }
+  for (let key of keys) {
+    // For each key of a, b must also have the key and the values must be equal
+    if (b[key] === undefined || a[key] !== b[key]) {
+    	return false;
+    }
+  }
+  return true;
+};


### PR DESCRIPTION
Added some code in `createTileGroupsFromBatchIDs` to check similar materials. If two groups of batch IDs have materials that share the same properties, only one material will be added.