### PR TITLE
Fix/tbi

### DIFF
--- a/UDV-Core/src/Utils/3DTiles/3DTilesBuildingUtils.js
+++ b/UDV-Core/src/Utils/3DTiles/3DTilesBuildingUtils.js
@@ -14,6 +14,18 @@ export function getBuildingIdFromIntersection(inter) {
   return table.content['cityobject.database_id'][bid];
 }
 
+export function getBuildingInfoFromBuildingId(tilesInfo, buildingId) {
+  for (let tileId of Object.keys(tilesInfo.tiles)) {
+    let tile = tilesInfo.tiles[tileId];
+    for (let batchId of Object.keys(tile)) {
+      let buildingInfo = tile[batchId];
+      if (buildingInfo.props['cityobject.database_id'] === buildingId) {
+        return buildingInfo;
+      }
+    }
+  }
+}
+
 /**
  * Sets the color of one building in the scene.
  * 

--- a/UDV-Core/src/Utils/3DTiles/3DTilesBuildingUtils.js
+++ b/UDV-Core/src/Utils/3DTiles/3DTilesBuildingUtils.js
@@ -1,8 +1,6 @@
 import { setTileVerticesColor, getBatchIdFromIntersection,
   getBatchTableFromTile, 
-  getTileInLayer,
-  getVisibleTiles,
-  getVerticesCentroid} from "./3DTilesUtils";
+  getTileInLayer} from "./3DTilesUtils";
 
 /**
  * Gets a building ID from an intersection. The intersecting object must
@@ -14,91 +12,6 @@ export function getBuildingIdFromIntersection(inter) {
   let table = getBatchTableFromTile(inter.object);
   let bid = getBatchIdFromIntersection(inter);
   return table.content['cityobject.database_id'][bid];
-}
-
-/**
- * Creates a Tile Building Info (TBI) dictionnary from a 3DTiles Layer.
- * The TBI is an object containing associations between Building Ids and
- * building-specific elements (mainly, the associated tile and the set of
- * batch array indexes).
- * 
- * @param {*} layer The 3DTiles layer.
- * @param {*} tbi An existing TBI for this layer. Tiles that are currently
- * loaded in the layer will be added to the TBI if they're not already present.
- * If no TBI is provided, a brand new one will be instantiated with currently
- * loaded tiles.
- * 
- * @example
- * let layer = view.getLayerById(config['3DTilesLayerID']);
- * //Fetch the TBI
- * let tbi = getTilesBuildingInfo(layer);
- * //Get a building ID from the mouse position
- * let intersections = view.pickObjectsAt(mouseEvent, 5);
- * let buildingId = getBuildingIdFromIntersection(
- *                   getFirst3dObjectIntersection(intersections));
- * //Display the building's infos
- * console.log(tbi.buildings[buildingId]);
- * 
- * @example
- * let layer = view.getLayerById(config['3DTilesLayerID']);
- * //Initialize the TBI
- * let tbi = getTilesBuildingInfo(layer);
- * //When the visible tiles change, update the TBI
- * tbi = getTilesBuildingInfo(layer, tbi);
- */
-export function getTilesBuildingInfo(layer, tbi = null) {
-  // Instantiate the TBI if it does not exist
-  if (!tbi) {
-    tbi = {};
-    tbi.totalTileCount = 0;
-    tbi.loadedTileCount = 0;
-    tbi.loadedTiles = {};
-    tbi.buildings = {};
-    tbi.tileset;
-  }
-  let tileIndex = layer.tileIndex;
-  let tileCount = Object.keys(tileIndex.index).length - 1; // -1 because of the
-                                                           // root tile
-  tbi.totalTileCount = tileCount;
-  let rootTile = layer.object3d.children[0];
-  tbi.tileset = rootTile;
-  let tiles = getVisibleTiles(layer);
-  // tiles contains every tile currently loaded in the scene. We iterate
-  // over them to visit the ones that we have not visited yet.
-  for (let tile of tiles) {
-    let tileId = tile.tileId;
-    // Check if this tile is already loaded (visited) in the TBI
-    if (!tbi.loadedTiles[tileId]) {
-      let batchTable = tile.batchTable;
-      let attributes = tile.children[0].children[0].geometry.attributes;
-      let newBuildingIds = [];
-      // For each vertex (ie. each batch ID), retrieve the associated building
-      // ID.
-      attributes._BATCHID.array.forEach((batchId, arrayIndex) => {
-        let buildingId = batchTable.content['cityobject.database_id'][batchId];
-        // Creates a dict entry for the building ID
-        if (!tbi.buildings[buildingId]) {
-          tbi.buildings[buildingId] = {};
-          tbi.buildings[buildingId].arrayIndexes = [];
-          tbi.buildings[buildingId].tileId = tile.tileId;
-          tbi.buildings[buildingId].batchId = batchId;
-          tbi.buildings[buildingId].centroid = null;
-
-          newBuildingIds.push(buildingId);
-        }
-        // Associates the vertex to the corresponding building ID
-        tbi.buildings[buildingId].arrayIndexes.push(arrayIndex);
-      });
-      // For each newly added building, compute the centroid
-      for (let buildingId of newBuildingIds) {
-        tbi.buildings[buildingId].centroid = getVerticesCentroid(tile,
-          tbi.buildings[buildingId].arrayIndexes);
-      }
-      tbi.loadedTiles[tileId] = true;
-      tbi.loadedTileCount += 1;
-    }
-  }
-  return tbi;
 }
 
 /**


### PR DESCRIPTION
- Changed the structure of the TBI to make it more generic :
  - The `buildings` and `loadedTiles` fields do not exist anymore
  - A new `tiles` field has appeared, it is a dictionnary with an entry for each loaded tile. The value of each entry is an array mapping batch IDs to building information.
  - A `props` field has been added to the building information. It takes the keys of the batch table and stores the appropriate value in the building information. For example, the previous building ID can be found under the `props['cityobject.database_id]` field.
- The function `getTilesBuildingInfo` is now called `getTilesInfo` (and a TBI should now be called a TI, for Tiles Information). As it is a generic structure, it is now located in `3DTilesUtils.js` and not `3DTilesBuildingUtils.js`.
- To access the TI with building IDs, a function called `getBuildingInfoFromBuildingId(tilesInfo, buildingId)` has been added to `3DTilesBuildingUtils.js`.

# Examples

## Creating a maintaning a TI :

```js
this.layer = itownsView.getLayerById(config['3DTilesLayerID']);
this.tilesInfo = null;
// Update the TI
this.tilesInfo = getTilesInfo(this.layer, this.tilesInfo);
```

## Accessing building info to apply a color :

```js
// From a tile ID and a batch ID (recommended)
let buildingInfo = this.tilesInfo.tiles[tileId][batchId];
// From a building ID
buildingInfo = getBuildingInfoFromBuildingId(this.tilesInfo, buildingId);

// Change the color
colorBuilding(this.layer, buildingInfo, [1, 0, 0]);
updateITownsView(this.iTownsView, this.layer);
```