### PR TITLE
Fix/3dtilesdebug

### DIFF
--- a/UDV-Core/src/Extensions/3DTilesDebug/views/3DTilesDebugWindow.js
+++ b/UDV-Core/src/Extensions/3DTilesDebug/views/3DTilesDebugWindow.js
@@ -138,13 +138,11 @@ export class Debug3DTilesWindow extends Window {
         // Find the building ID we clicked on
         let table = getBatchTableFromTile(firstInter.object);
         let batchId = getBatchIdFromIntersection(firstInter);
-        let buildingId = table.content['cityobject.database_id'][batchId];
         let tileId = getObject3DFromTile(firstInter.object).tileId;
 
         this.hoveredTileId = tileId;
         this.hoveredBatchId = batchId;
-        this.hoverDivElement.innerHTML = `Building ID : ${buildingId}<br>
-                                          Batch ID : ${batchId}<br>
+        this.hoverDivElement.innerHTML = `Batch ID : ${batchId}<br>
                                           Tile ID : ${tileId}`;
       } else {
         this.hoveredTileId = null;
@@ -177,11 +175,13 @@ export class Debug3DTilesWindow extends Window {
           console.log(buildingInfo);
           // Fill a div with the info
           this.clickDivElement.innerHTML = /*html*/`
-            Building ID : ${buildingInfo.props['cityobject.database_id']}<br>
             ${buildingInfo.arrayIndexes.length} array indexes<br>
             Batch ID : ${buildingInfo.batchId}<br>
             Tile ID : ${buildingInfo.tileId}
           `;
+          for (let [key, value] of Object.entries(buildingInfo.props)) {
+            this.clickDivElement.innerHTML += `<br>${key} : ${value}`;
+          }
           // If a building was already selected, un-color its tile
           if (!!this.selectedBuildingInfo) {
             let tile = getTileInTileset(this.tilesInfo.tileset,

--- a/UDV-Core/src/Extensions/DocumentLinks/views/DocumentLinkWindow.js
+++ b/UDV-Core/src/Extensions/DocumentLinks/views/DocumentLinkWindow.js
@@ -327,8 +327,12 @@ export class DocumentLinkWindow extends Window {
         this.tilesInfo = getTilesInfo(this.layer, this.tilesInfo);
         let buildingInfo = this.tilesInfo.tiles[tileId][batchId];
         if (!!buildingInfo) {
+          let buildingId = buildingInfo.props['cityobject.database_id'];
+          if (buildingId === undefined) {
+            throw 'No building ID in the city object.';
+          }
           this.selectedBuildingParagraphElement.innerHTML = /*html*/`
-            Selected building ID : ${buildingInfo.props['cityobject.database_id']}<br>
+            Selected building ID : ${buildingId}<br>
             Tile ID : ${buildingInfo.tileId}<br>
             Batch ID : ${buildingInfo.batchId}
           `;
@@ -351,9 +355,13 @@ export class DocumentLinkWindow extends Window {
     if (!!this.selectedTileId) {
       let formData = new FormData();
       formData.append('source_id', this.documentController.getCurrentDoc().id);
-      formData.append('target_id', this.tilesInfo
+      let buildingId = this.tilesInfo
         .tiles[this.selectedTileId][this.selectedBatchId]
-        .props['cityobject.database_id']);
+        .props['cityobject.database_id'];
+      if (buildingId === undefined) {
+        throw 'No building ID in the city object.';
+      }
+      formData.append('target_id', buildingId);
       let centroid = this.selectedBuildingInfo.centroid;
       formData.append('centroid_x', centroid.x);
       formData.append('centroid_y', centroid.y);


### PR DESCRIPTION
- Removed a dependency from 3DTilesDebug on the attribute 'cityobject.database_id'
- DocumentLinksWindow now throws an error when the attribute 'cityobject.database_id' is not present