### PR TITLE
Fix/3dtiles manager

### DIFF
--- a/UDV-Core/examples/DemoFull/Demo.js
+++ b/UDV-Core/examples/DemoFull/Demo.js
@@ -71,8 +71,7 @@ baseDemo.loadConfigFile('../data/config/generalDemoConfig.json').then(() => {
                                 name: 'Address Search'});
 
     ////// 3DTILES DEBUG
-    const debug3dTilesWindow = new udvcore.Debug3DTilesWindow(baseDemo.view,
-        baseDemo.config);
+    const debug3dTilesWindow = new udvcore.Debug3DTilesWindow(baseDemo.tilesManager);
     baseDemo.addModuleView('3dtilesDebug', debug3dTilesWindow, {
         name: '3DTiles Debug'
     });

--- a/UDV-Core/src/Extensions/3DTilesDebug/examples/Demo.js
+++ b/UDV-Core/src/Extensions/3DTilesDebug/examples/Demo.js
@@ -12,7 +12,7 @@ baseDemo.loadConfigFile('../../../../examples/data/config/generalDemoConfig.json
     baseDemo.init3DView();
 
     ////// 3DTILES DEBUG
-    const debug3dTilesWindow = new udvcore.Debug3DTilesWindow(baseDemo.view, baseDemo.config);
+    const debug3dTilesWindow = new udvcore.Debug3DTilesWindow(baseDemo.tilesManager);
     baseDemo.addModuleView('3dtilesDebug', debug3dTilesWindow, {
         name: '3DTiles Debug'
     });

--- a/UDV-Core/src/Extensions/3DTilesDebug/views/3DTilesDebugWindow.js
+++ b/UDV-Core/src/Extensions/3DTilesDebug/views/3DTilesDebugWindow.js
@@ -163,9 +163,13 @@ export class Debug3DTilesWindow extends Window {
     try {
       let tileId = Number.parseInt(this.groupColorTileInputElement.value);
       let batchIds = JSON.parse('[' + this.groupColorBatchInputElement.value + ']');
+      let cityObjectIds = [];
+      for (let batchId of batchIds) {
+        cityObjectIds.push(new CityObjectID(tileId, batchId));
+      }
       let color = new THREE.Color(this.groupColorColorInputElement.value);
       let opacity = Number.parseFloat(this.groupColorOpacityInputElement.value);
-      this.tilesManager.setStyle(new CityObjectID(tileId, batchIds),
+      this.tilesManager.setStyle(cityObjectIds, 
         {materialProps: {color, opacity}});
       this.tilesManager.applyStyles();
     } catch (e) {

--- a/UDV-Core/src/Extensions/3DTilesDebug/views/3DTilesDebugWindow.js
+++ b/UDV-Core/src/Extensions/3DTilesDebug/views/3DTilesDebugWindow.js
@@ -6,13 +6,20 @@ import { CityObjectStyle } from "../../../Utils/3DTiles/Model/CityObjectStyle";
 import { CityObjectID } from "../../../Utils/3DTiles/Model/CityObject";
 
 export class Debug3DTilesWindow extends Window {
-  constructor(itownsView, config) {
+  /**
+   * Creates the debug window.
+   * 
+   * @param {TilesManager} tilesManager The tiles manager.
+   */
+  constructor(tilesManager) {
     super('3d_tiles_debug', '3DTiles Debug', false);
 
-    this.itownsView = itownsView;
-    this.layer = itownsView.getLayerById(config['3DTilesLayerID']);
-    // Tiles Manager
-    this.tilesManager = new TilesManager(this.itownsView, this.layer)
+    /**
+     * The tiles manager.
+     * 
+     * @type {TilesManager}
+     */
+    this.tilesManager = tilesManager;
 
     // Selection
     this.tilesManager.registerStyle('selected', new CityObjectStyle({
@@ -121,7 +128,7 @@ export class Debug3DTilesWindow extends Window {
    */
   onMouseMove(event) {
     // Update the current visible tile count
-    let visibleTileCount = getVisibleTileCount(this.layer);
+    let visibleTileCount = getVisibleTileCount(this.tilesManager.layer);
     this.visibleTilesParagraphElement.innerText = `${visibleTileCount} tiles visible.`
   }
 
@@ -133,7 +140,6 @@ export class Debug3DTilesWindow extends Window {
    * @param {MouseEvent} event The mouse event.
    */
   onMouseClick(event) {
-    this.tilesManager.update();
     let cityObject = this.tilesManager.pickCityObject(event);
     if (cityObject !== undefined) {
       this.clickDivElement.innerHTML = /*html*/`
@@ -152,7 +158,8 @@ export class Debug3DTilesWindow extends Window {
 
       this.selectedCityObject = cityObject;
       this.tilesManager.setStyle(this.selectedCityObject.cityObjectId, 'selected');
-      this.tilesManager.applyStyles();
+      this.tilesManager.applyStyles({updateFunction:
+        this.tilesManager.view.notifyChange.bind(this.tilesManager.view)});
     }
   }
 

--- a/UDV-Core/src/Utils/3DTiles/3DTilesUtils.js
+++ b/UDV-Core/src/Utils/3DTiles/3DTilesUtils.js
@@ -1,4 +1,4 @@
-import * as THREE from '../../../node_modules/three/build/three.js';
+import * as THREE from '../../../node_modules/three/build/three.module.js';
 import { objectEquals } from '../DataProcessing/DataProcessing.js';
 
 /**

--- a/UDV-Core/src/Utils/3DTiles/Docs/StyleManager.md
+++ b/UDV-Core/src/Utils/3DTiles/Docs/StyleManager.md
@@ -99,7 +99,39 @@ for (let tileId of tilesToUpdate) {
 
 ### Storage of styles
 
+In a `StyleManager`, a style can be either _anonymous_ or _registered_ (also called _named_). A named style is a style that was first associated with a name by using the `registerStyle` method. On the other hand, an anonymous style is a `CityObjectStyle` that has been passed directly as the second parameter of the `setStyle` method :
+
+```js
+// Named style
+styleManager.registerStyle('red', new CityObjectStyle({materialProps: {color: 0xff0000}}));
+styleManager.setStyle(new CityObjectID(6, 64), 'red');
+
+// Anonymous style
+styleManager.setStyle(new CityObjectID(6, 64), new CityObjectStyle({materialProps: {color: 0xff0000}}));
+```
+
+The `StyleManager` uses two types of storage for these styles. The named styles are kept in a dictionnary called `registeredStyles` where the keys are the names of the styles, and the values the styles themselves. The anonymous styles are stored in an array called `anonymousStyles`.
+
+Using two different structures allows the style manager to use a generic identifier to reference the stored styles. If a string is used as an identifier, we know that it references a named style, whereas if a number is used, we know that it represents an index in the anonymous styles array.
+
+The structure used to associated city objects with their respective style is a field called `styleTable`. The style table is a dictionnary where the key is a tile ID, and the value is another dictionnary that associates batch IDs of the tile to style identifiers. Style identifiers, as said before, are strings or numbers depending on wether they refer to anonymous or named styles.
+
+There are a few things to know about anonymous and named styles when using them :
+
+- When using an anonymous style in the `setStyle` method, the `StyleManager` will parse the `anonymousStyles` array to determine wether a similar style has already been registered. This is done by calling the `equals` method of `CityObjectStyle`. If an equivalent anonymous style is found, the style identifier associated to the city object will be the index of the matching style. Otherwise, the style will be pushed into the anonymous array and its new index will be used as a style identifier.
+- When registering a style with the `registerStyle` method, two cases can happen : either a style with the same name already exist or not. If the style was already registered, it is simply updated with the new values. This means that the city objects associated with this name will be applied the new style.
+- When adding a named style in the `registeredStyles` structure, the `StyleManager` does not check if a style with the same properties already exist. This mean you can have duplicate named style.
+
+Some methods of `StyleManager` allow to access styles :
+
+- `getStyle(styleIdentifier)` returns a style identified by the argument. It can either be a string or a number, depending on the style being _named_ or _anonymous_.
+- `getStyleAppliedTo(cityObjectId)` returns the style associated to the city object in argument.
+
 ### Reverse storage for finding usage
+
+The `StyleManager` also allows its user to access city objects associated with specific styles. This is the role of the `getStyleUsage(styleIdentifier)` function : by passing a style identifier (can be theorically a string or a number, however the user does not have access to anonymous style indexes so the main use case will be with registered styles), this function returns a dictionnary that maps tile IDs to arrays of batch IDs. This structure represents all city objects that have the given style.
+
+To do that efficiently, the `StyleManger` stores two structures, respectively called `registeredStyleUsage` and `anonymousStyleUsage`. They work the same way : 
 
 ### Applying styles
 

--- a/UDV-Core/src/Utils/3DTiles/Model/CityObject.js
+++ b/UDV-Core/src/Utils/3DTiles/Model/CityObject.js
@@ -8,25 +8,24 @@ export class CityObject {
   /**
    * Constructs a city object from the given parameters.
    * 
-   * @param {Tile} tile The parent tile.
-   * @param {number} batchId Batch ID of the city object in the parent tile.
-   * @param {number} indexStart Start index of the vertex array in the parent
-   * tile.
+   * @param {Tile} tile The tile holding the city object.
+   * @param {number} batchId Batch ID of the city object in the tile.
+   * @param {number} indexStart Start index of the vertex array in the tile.
    * @param {number} [indexCount] Number of vertices corresponding to this batch
-   * ID in the parent tile.
+   * ID in the tile.
    * @param {THREE.Vector3} [centroid] Centroid of the geometry.
    * @param {Object} [props] Properties from the batch table.
    */
   constructor(tile, batchId, indexStart, indexCount, centroid, props) {
     /**
-     * The parent tile.
+     * The tile holding the city object.
      * 
      * @type {Tile}
      */
     this.tile = tile;
 
     /**
-     * Batch ID of the city object in the parent tile.
+     * Batch ID of the city object in the tile.
      * 
      * @type {number}
      */
@@ -40,14 +39,14 @@ export class CityObject {
     this.cityObjectId = new CityObjectID(this.tile.tileId, this.batchId);
 
     /**
-     * Start index of the vertex array in the parent tile.
+     * Start index of the vertex array in the tile.
      * 
      * @type {number}
      */
     this.indexStart = indexStart;
 
     /**
-     * Number of vertices corresponding to this batch ID in the parent tile.
+     * Number of vertices corresponding to this batch ID in the tile.
      * 
      * @type {number}
      */
@@ -105,7 +104,7 @@ export class CityObjectID {
    * Constructs a city object ID.
    * 
    * @param {number} tileId The parent tile ID.
-   * @param {number | Array<number>} batchId The batch ID in the tile.
+   * @param {number} batchId The batch ID in the tile.
    */
   constructor(tileId, batchId) {
     /**
@@ -121,21 +120,6 @@ export class CityObjectID {
      * @type {number}
      */
     this.batchId = batchId;
-  }
-
-  /**
-   * Checks wether the city object ID identifies a single city object.
-   */
-  isSingleCityObject() {
-    return typeof(this.batchId) === 'number';
-  }
-
-  /**
-   * Checks wether the city object ID identifies an array of city objects in a
-   * tile.
-   */
-  isMultipleCityObjects() {
-    return Array.isArray(this.batchId);
   }
 
   /**

--- a/UDV-Core/src/Utils/3DTiles/Model/CityObject.js
+++ b/UDV-Core/src/Utils/3DTiles/Model/CityObject.js
@@ -1,5 +1,5 @@
-import { Tile } from "./Tile";
-import * as THREE from 'three';
+import { Tile } from "./Tile.js";
+import * as THREE from '../../../../node_modules/three/build/three.js';
 
 /**
  * Represents a city object.

--- a/UDV-Core/src/Utils/3DTiles/Model/CityObjectStyle.js
+++ b/UDV-Core/src/Utils/3DTiles/Model/CityObjectStyle.js
@@ -1,5 +1,3 @@
-import { objectEquals } from "../../DataProcessing/DataProcessing";
-
 /**
  * Represents the style of a tile part. Accepted parameters are :
  * 

--- a/UDV-Core/src/Utils/3DTiles/Model/Tile.js
+++ b/UDV-Core/src/Utils/3DTiles/Model/Tile.js
@@ -1,6 +1,6 @@
-import * as THREE from 'three';
-import { CityObject } from './CityObject';
-import { getTileInLayer } from '../3DTilesUtils';
+import * as THREE from '../../../../node_modules/three/build/three.module.js';
+import { CityObject } from './CityObject.js';
+import { getTileInLayer } from '../3DTilesUtils.js';
 
 /**
  * Represents a tile from 3DTiles. It holds a reference to the tile ID and the

--- a/UDV-Core/src/Utils/3DTiles/StyleManager.js
+++ b/UDV-Core/src/Utils/3DTiles/StyleManager.js
@@ -115,8 +115,8 @@ export class StyleManager {
   /**
    * Sets the style of the given city object.
    * 
-   * @param {CityObjectID | Array<CityObjectID>} cityObjectId The ID of the city
-   * object.
+   * @param {CityObjectID | Array<CityObjectID>} cityObjectId One or many IDs of 
+   * the city objects.
    * @param {CityObjectStyle | string} style The style to apply. Can be a
    * `CityObjectStyle` or a `string` refering a registered style.
    */
@@ -140,7 +140,6 @@ export class StyleManager {
    * @private
    * 
    * @param {CityObjectStyle} style The style to register.
-   * 
    * @returns {number} The index of the style in the anonymous style array.
    */
   _registerAnonymousStyle(style) {
@@ -172,7 +171,7 @@ export class StyleManager {
    * @private
    * 
    * @param {CityObjectID | Array<CityObjectID>} cityObjectId The city object
-   * identifier.
+   * identifier, or an array of city object identifiers.
    * @param {number | string} styleIdentifier The style identifier.
    */
   _setStyleInTable(cityObjectId, styleIdentifier) {

--- a/UDV-Core/src/Utils/3DTiles/StyleManager.js
+++ b/UDV-Core/src/Utils/3DTiles/StyleManager.js
@@ -1,7 +1,7 @@
-import { CityObjectStyle } from "./Model/CityObjectStyle";
-import { CityObjectID } from "./Model/CityObject";
-import { createTileGroups } from "./3DTilesUtils";
-import { Tile } from "./Model/Tile";
+import { CityObjectStyle } from "./Model/CityObjectStyle.js";
+import { CityObjectID } from "./Model/CityObject.js";
+import { createTileGroups } from "./3DTilesUtils.js";
+import { Tile } from "./Model/Tile.js";
 
 /**
  * Class used to manage the styles of city objects.

--- a/UDV-Core/src/Utils/3DTiles/StyleManager.js
+++ b/UDV-Core/src/Utils/3DTiles/StyleManager.js
@@ -115,7 +115,8 @@ export class StyleManager {
   /**
    * Sets the style of the given city object.
    * 
-   * @param {CityObjectID} cityObjectId The ID of the city object.
+   * @param {CityObjectID | Array<CityObjectID>} cityObjectId The ID of the city
+   * object.
    * @param {CityObjectStyle | string} style The style to apply. Can be a
    * `CityObjectStyle` or a `string` refering a registered style.
    */
@@ -135,6 +136,8 @@ export class StyleManager {
    * Checks if the given style exists in the anonymous style array, and returns
    * the index if this is the case. Else, push the style in the anonymous style
    * array and returns the index.
+   * 
+   * @private
    * 
    * @param {CityObjectStyle} style The style to register.
    * 
@@ -168,26 +171,35 @@ export class StyleManager {
    * 
    * @private
    * 
-   * @param {CityObjectID} cityObjectId The city object identifier.
+   * @param {CityObjectID | Array<CityObjectID>} cityObjectId The city object
+   * identifier.
    * @param {number | string} styleIdentifier The style identifier.
    */
   _setStyleInTable(cityObjectId, styleIdentifier) {
-    let tileId = cityObjectId.tileId;
-
-    if (this.styleTable[tileId] === undefined) {
-      this.styleTable[tileId] = {};
-    }
-    if (cityObjectId.isSingleCityObject()) {
+    if (cityObjectId instanceof CityObjectID) {
+      let tileId = cityObjectId.tileId;
+  
+      if (this.styleTable[tileId] === undefined) {
+        this.styleTable[tileId] = {};
+      }
       this.styleTable[tileId][cityObjectId.batchId] = styleIdentifier;
-    } else if (cityObjectId.isMultipleCityObjects()) {
-      for (let batchId of cityObjectId.batchId) {
-        this.styleTable[tileId][batchId] = styleIdentifier;
+      this._bufferStyleMaterial(cityObjectId.tileId, styleIdentifier);
+      this._registerUsage(styleIdentifier, cityObjectId);
+    } else if (Array.isArray(cityObjectId)) {
+      cityObjectId.sort((idA, idB) => {
+        return idA.tileId - idB.tileId
+      });
+      for (let id of cityObjectId) {
+        if (this.styleTable[id.tileId] === undefined) {
+          this.styleTable[id.tileId] = {};
+        }
+        this.styleTable[id.tileId][id.batchId] = styleIdentifier;
+        this._bufferStyleMaterial(id.tileId, styleIdentifier);
+        this._registerUsage(styleIdentifier, id);
       }
     } else {
       throw 'Invalid city object Identifier';
     }
-    this._bufferStyleMaterial(cityObjectId.tileId, styleIdentifier);
-    this._registerUsage(styleIdentifier, cityObjectId);
   }
 
   /**
@@ -225,22 +237,24 @@ export class StyleManager {
   /**
    * Removes the style associated with this city object.
    * 
-   * @param {CityObjectID} cityObjectId The city object ID.
+   * @param {CityObjectID | Array<CityObjectID>} cityObjectId The city object
+   * ID.
    */
   removeStyle(cityObjectId) {
-    if (this.styleTable[cityObjectId.tileId] === undefined) {
-      return;
-    }
-    if (cityObjectId.isSingleCityObject()) {
+    if (cityObjectId instanceof CityObjectID) {
+      if (this.styleTable[cityObjectId.tileId] === undefined) {
+        return;
+      }
       this._removeUsage(this.styleTable[cityObjectId.tileId][cityObjectId.batchId],
         cityObjectId);
       delete this.styleTable[cityObjectId.tileId][cityObjectId.batchId];
-    } else {
-      for (let batchId of cityObjectId.batchId) {
-        this._removeUsage(this.styleTable[cityObjectId.tileId][batchId],
-          new CityObjectID(cityObjectId.tileId, batchId));
-        delete this.styleTable[cityObjectId.tileId][batchId];
+    } else if (Array.isArray(cityObjectId)) {
+      for (let id of cityObjectId) {
+        this._removeUsage(this.styleTable[id.tileId][id.batchId], id);
+        delete this.styleTable[id.tileId][id.batchId];
       }
+    } else {
+      throw 'Invalid City Object Identifier';
     }
   }
 
@@ -253,13 +267,13 @@ export class StyleManager {
     if (this.styleTable[tileId] === undefined) {
       return;
     }
-    let batchIds = [];
+    let cityObjectIds = [];
     for (let batchId of Object.keys(this.styleTable[tileId])) {
-      batchIds.push(Number(batchId));
+      cityObjectIds.push(new CityObjectID(tileId, Number(batchId)));
     }
     
     delete this.tileBufferedMaterials[tileId];
-    this.removeStyle(new CityObjectID(tileId, batchIds));
+    this.removeStyle(cityObjectIds);
   }
 
   /**
@@ -281,7 +295,7 @@ export class StyleManager {
    */
   applyToTile(tile) {
     if (this.styleTable[tile.tileId] !== undefined) {
-      let materials = this.tileBufferedMaterials[tile.tileId];
+      let materials = this.tileBufferedMaterials[tile.tileId] || [];
       let ranges = [];
       for (let batchId of Object.keys(this.styleTable[tile.tileId])) {
         let styleIdentifier = this.styleTable[tile.tileId][batchId];
@@ -348,10 +362,6 @@ export class StyleManager {
       return undefined;
     }
 
-    let batchId = cityObjectId.isSingleCityObject() ?
-      cityObjectId.batchId :
-      cityObjectId.batchId[0];
-
     if (this.styleTable[cityObjectId.tileId][cityObjectId.batchId]
       === undefined) {
       return undefined;
@@ -380,11 +390,7 @@ export class StyleManager {
       if (this.registeredStyleUsage[styleIdentifier][tileId] === undefined) {
         this.registeredStyleUsage[styleIdentifier][tileId] = [];
       }
-      if (cityObjectId.isSingleCityObject()) {
-        this.registeredStyleUsage[styleIdentifier][tileId].push(batchId);
-      } else {
-        this.registeredStyleUsage[styleIdentifier][tileId].push(...batchId);
-      }
+      this.registeredStyleUsage[styleIdentifier][tileId].push(batchId);
     } else if (typeof(styleIdentifier) === 'number') {
       if (this.anonymousStyleUsage[styleIdentifier] === undefined) {
         this.anonymousStyleUsage[styleIdentifier] = {};
@@ -392,11 +398,7 @@ export class StyleManager {
       if (this.anonymousStyleUsage[styleIdentifier][tileId] === undefined) {
         this.anonymousStyleUsage[styleIdentifier][tileId] = [];
       }
-      if (cityObjectId.isSingleCityObject()) {
-        this.anonymousStyleUsage[styleIdentifier][tileId].push(batchId);
-      } else {
-        this.anonymousStyleUsage[styleIdentifier][tileId].push(...batchId);
-      }
+      this.anonymousStyleUsage[styleIdentifier][tileId].push(batchId);
     } else {
       throw 'A style identifier must be a string or a number.';
     }
@@ -408,15 +410,18 @@ export class StyleManager {
    * @private
    * 
    * @param {string | number} styleIdentifier The style identifier.
-   * @param {CityObjectID} cityObjectId The city object ID.
+   * @param {CityObjectID | Array<CityObjectID>} cityObjectId The city object
+   * ID.
    */
   _removeUsage(styleIdentifier, cityObjectId) {
-    if (cityObjectId.isSingleCityObject()) {
-      this._removeUsageInTables(styleIdentifier, cityObjectId.tileId, cityObjectId.batchId);
-    } else {
-      for (let batchId of cityObjectId.batchId) {
-        this._removeUsageInTables(styleIdentifier, cityObjectId.tileId, batchId);
+    if (cityObjectId instanceof CityObjectID) {
+      this._removeUsageInTables(styleIdentifier, cityObjectId);
+    } else if (Array.isArray(cityObjectId)) {
+      for (let id of cityObjectId) {
+        this._removeUsageInTables(styleIdentifier, id);
       }
+    } else {
+      throw 'Invalid City Object Identifier';
     }
   }
   
@@ -424,10 +429,11 @@ export class StyleManager {
    * Removes the track of the style for one single city object.
    * 
    * @param {string | number} styleIdentifier The style identifier
-   * @param {number} tileId The tile ID.
-   * @param {number} batchId The batch ID.
+   * @param {CityObjectID} cityObjectId The city object ID.
    */
-  _removeUsageInTables(styleIdentifier, tileId, batchId) {
+  _removeUsageInTables(styleIdentifier, cityObjectId) {
+    let tileId = cityObjectId.tileId;
+    let batchId = cityObjectId.batchId;
     if (typeof(styleIdentifier) === 'string') {
       let index = this.registeredStyleUsage[styleIdentifier][tileId].findIndex(
         bId => bId === batchId);

--- a/UDV-Core/src/Utils/3DTiles/StyleManager.js
+++ b/UDV-Core/src/Utils/3DTiles/StyleManager.js
@@ -67,9 +67,32 @@ export class StyleManager {
    * re-applied.
    */
   registerStyle(name, style) {
+    this._updateBufferedMaterials(name, style);
+
     let existing = this.registeredStyles[name] !== undefined;
     this.registeredStyles[name] = style;
     return existing;
+  }
+
+  /**
+   * Updates the buffer material when a named style is updated.
+   * 
+   * @private
+   * 
+   * @param {string} name Name of the registered style.
+   * @param {CityObjectStyle} style The style to register.
+   */
+  _updateBufferedMaterials(name, style) {
+    let previousStyle = this.registeredStyles[name];
+    if (previousStyle !== undefined &&
+      previousStyle._bufferedMaterialIndex !== undefined) {
+      // Need to keep the buffered material
+      style._bufferedMaterialIndex = previousStyle._bufferedMaterialIndex;
+      for (let tileId of Object.keys(style._bufferedMaterialIndex)) {
+        let index = style._bufferedMaterialIndex[tileId];
+        this.tileBufferedMaterials[tileId][index] = style.materialProps;
+      }
+    }
   }
 
   /**

--- a/UDV-Core/src/Utils/BaseDemo/js/BaseDemo.js
+++ b/UDV-Core/src/Utils/BaseDemo/js/BaseDemo.js
@@ -1,4 +1,5 @@
 import { ModuleView } from '../../ModuleView/ModuleView.js';
+import { TilesManager } from '../../3DTiles/TilesManager.js';
 
 /**
  * Represents the base HTML content of a demo for UDV and provides methods to
@@ -17,6 +18,12 @@ export class BaseDemo {
         this.view;  // itowns view (3d scene)
         this.extent;  // itowns extent (city limits)
         this.controls;
+        /**
+         * Object used to manage the 3DTiles layer.
+         * 
+         * @type {TilesManager}
+         */
+        this.tilesManager;
         // Temporal is currently disabled and will be reintroduced in a new
         // version based on a 3D Tiles extension
         this.temporal = false;
@@ -440,6 +447,10 @@ export class BaseDemo {
 
         // Request itowns view redraw
         this.view.notifyChange();
+
+        // Initialize the 3DTiles manager
+        this.tilesManager = new TilesManager(this.view,
+            this.view.getLayerById(this.config['3DTilesLayerID']));
     }
 
     /**


### PR DESCRIPTION
- Fixed a bug where buffered materials did not update on registerStyle with new styles
- Added some documentation for `StyleManager` (still not complete yet)
- Changed `CityObjectID` so that it identifies only one city object; changed the methods that takes a `CityObjectID` as argument so that they accept arrays of city object IDs
- Move the `TilesManager` instance in `BaseDemo` so that the same instance can be accessed by every module
- Added an `options` argument in `TilesManager.applyStyles` to specify the update function :

```js
this.tilesManager.applyStyles({
  updateFunction: this.view.notifyChange.bind(this.view)
});
```