### PR TITLE
Failed requests return response text

### DIFF
--- a/UDV-Core/src/Utils/Request/RequestService.js
+++ b/UDV-Core/src/Utils/Request/RequestService.js
@@ -77,7 +77,7 @@ export function RequestService() {
                 if (req.status >= 200 && req.status < 300) {
                     resolve(req);
                 } else {
-                    reject(req);
+                    reject(req.responseText);
                 }
             }
         });


### PR DESCRIPTION
When a requests fails, instead of throwing the `XHTTPRequest` object, the actual response text is returned. This means that this code :

```js
try {
  requestService.request(...);
} catch (e) {
  alert(e);
}
```

Will print text understandable by a human instead of `[XHTTPRequest object]`.